### PR TITLE
fix: improve esbuild's logLevel of warnings (batijs/bati#89)

### DIFF
--- a/packages/vercel/src/build.ts
+++ b/packages/vercel/src/build.ts
@@ -92,6 +92,10 @@ const standardBuildOptions: BuildOptions = {
   format: 'cjs',
   platform: 'node',
   logLevel: 'info',
+  logOverride: {
+    'ignored-bare-import': 'verbose',
+    'require-resolve-not-external': 'verbose'
+  },
   minify: true,
   plugins: [wasmPlugin],
 };


### PR DESCRIPTION
Suppress chatty warnings https://github.com/batijs/bati/issues/89.

- https://esbuild.github.io/api/#log-override:~:text=Ignoring%20this%20import%20because%20%22node_modules/foo/index.js%22%20was%20marked%20as%20having%20no%20side%20effects => I think it's fine to hide this warning by default, and I'd argue esbuild is being too conservative here.
- https://esbuild.github.io/api/#log-override:~:text=%22foo%22%20should%20be%20marked%20as%20external%20for%20use%20with%20%22require.resolve%22%20%5Brequire%2Dresolve%2Dnot%2Dexternal%5D => I think it's safe to hide it by default, as this warning seems to be relevant only in a browser context: in my experience Vercel can handle `require.resolve()` just fine.