### PR TITLE
use vike ^0.4.162 - earlier versions don't work with v5

### DIFF
--- a/packages/vike-integration/package.json
+++ b/packages/vike-integration/package.json
@@ -43,7 +43,7 @@
     "nanoid": "^5.0.6"
   },
   "peerDependencies": {
-    "vike": "*",
+    "vike": "^0.4.162",
     "vite": "^4.4 || ^5.0.2",
     "vite-plugin-vercel": "*"
   },


### PR DESCRIPTION
Hey, I just saw that you released v5, nice work!

I'm still on `0.4.161` of vike which is incompatible with v5 of this lib. The error it throws is `[vike][Wrong Usage] /node_modules/@vite-plugin-vercel/vike/dist/+config.js defines an unknown config name, you need to define the config name by using config.meta https://vike.dev/meta`

The version of vike that added the `name` property is `0.4.162` so I figured it makes sense to be explicit about that.