### PR TITLE
Use entry's buildOptions instead of the argument

### DIFF
--- a/packages/vercel/src/build.ts
+++ b/packages/vercel/src/build.ts
@@ -109,7 +109,6 @@ const standardBuildOptions: BuildOptions = {
 export async function buildFn(
   resolvedConfig: ResolvedConfig,
   entry: ViteVercelApiEntry,
-  buildOptions?: BuildOptions,
 ) {
   assert(
     entry.destination.length > 0,
@@ -120,8 +119,8 @@ export async function buildFn(
 
   const options = Object.assign({}, standardBuildOptions);
 
-  if (buildOptions) {
-    Object.assign(options, buildOptions);
+  if (entry.buildOptions) {
+    Object.assign(options, entry.buildOptions);
   }
 
   const filename =


### PR DESCRIPTION
This PR uses `entry.buildOptions`, so that it's possible to configure things such as sourcemap support for a specific entry. 