### PR TITLE
fix: edge esbuild conditions

### DIFF
--- a/packages/vercel/src/build.ts
+++ b/packages/vercel/src/build.ts
@@ -1,5 +1,6 @@
 import { ResolvedConfig } from 'vite';
 import glob from 'fast-glob';
+import { builtinModules } from 'module'
 import path, { basename } from 'path';
 import { getOutput, getRoot, pathRelativeTo } from './utils';
 import { build, BuildOptions, type Plugin } from 'esbuild';
@@ -154,8 +155,11 @@ export async function buildFn(
   }
 
   if (entry.edge) {
+    delete options.platform;
+    options.external = [...builtinModules, ...builtinModules.map((m) => `node:${m}`)]
     options.conditions = [
       'edge-light',
+      'worker',
       'browser',
       'module',
       'import',


### PR DESCRIPTION
❌ Example issue without `'worker'` condition:
```
// ../../node_modules/.pnpm/react-streaming@0.3.42_react-dom@18.3.1_react@18.3.1__react@18.3.1/node_modules/react-streaming/dist/esm/server/client-poison-pill.js
var init_client_poison_pill = __esm({
  "../../node_modules/.pnpm/react-streaming@0.3.42_react-dom@18.3.1_react@18.3.1__react@18.3.1/node_modules/react-streaming/dist/esm/server/client-poison-pill.js"() {
    init_utils4();
    assertUsage3(false, "`import { something } from 'react-streaming/server'` in client-side code is forbidden: the module react-streaming/server should never be loaded on the client-side");
  }
});
```

✅ With `'worker'` condition:
```
// ../../node_modules/.pnpm/react-streaming@0.3.42_react-dom@18.3.1_react@18.3.1__react@18.3.1/node_modules/react-streaming/dist/esm/server/index.web-only.js
var init_index_web_only = __esm({
  "../../node_modules/.pnpm/react-streaming@0.3.42_react-dom@18.3.1_react@18.3.1__react@18.3.1/node_modules/react-streaming/dist/esm/server/index.web-only.js"() {
    init_server();
    init_renderToWebStream();
    init_renderToStream();
    renderToWebStream_set(renderToWebStream);
  }
});
```


❌ Example issue with `platform: 'node'`:
```
// ../../node_modules/.pnpm/react-dom@18.3.1_react@18.3.1/node_modules/react-dom/cjs/react-dom-server-legacy.node.production.min.js
var require_react_dom_server_legacy_node_production_min = __commonJS({
  "../../node_modules/.pnpm/react-dom@18.3.1_react@18.3.1/node_modules/react-dom/cjs/react-dom-server-legacy.node.production.min.js"(exports) {
    "use strict";
    var ea = require_react();
    var fa = __require("stream");
```

Seems like `platform: 'node'` overrides conditions.


