### PR TITLE
feat: Vike `edge` config support

### DIFF
--- a/examples/demo/pages/vike-edge/+Page.tsx
+++ b/examples/demo/pages/vike-edge/+Page.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import { Counter } from "./Counter.js";
+
+export default function Page() {
+  return (
+    <>
+      <h1>Welcome</h1>
+      This page is:
+      <ul>
+        <li>Rendered to HTML.</li>
+        <li>
+          Interactive. <Counter />
+        </li>
+      </ul>
+    </>
+  );
+}

--- a/examples/demo/pages/vike-edge/+config.ts
+++ b/examples/demo/pages/vike-edge/+config.ts
@@ -1,0 +1,5 @@
+import type { Config } from "vike/types";
+
+export default {
+  edge: true,
+} satisfies Config;

--- a/examples/demo/pages/vike-edge/+config.ts
+++ b/examples/demo/pages/vike-edge/+config.ts
@@ -1,5 +1,6 @@
 import type { Config } from "vike/types";
 
 export default {
+  prerender: false,
   edge: true,
 } satisfies Config;

--- a/examples/demo/pages/vike-edge/Counter.tsx
+++ b/examples/demo/pages/vike-edge/Counter.tsx
@@ -1,0 +1,12 @@
+import React, { useState } from "react";
+
+export { Counter };
+
+function Counter() {
+  const [count, setCount] = useState(0);
+  return (
+    <button type="button" onClick={() => setCount((count) => count + 1)}>
+      Counter {count}
+    </button>
+  );
+}

--- a/examples/demo/renderer/PageShell.tsx
+++ b/examples/demo/renderer/PageShell.tsx
@@ -27,6 +27,7 @@ function PageShell({
             <Link href="/catch-all/a/b/c">Catch-all</Link>
             <Link href="/function/a">Function</Link>
             <Link href="/edge">Edge Function endpoint</Link>
+            <Link href="/vike-edge">Vike Edge Function endpoint</Link>
             <Link href="/og-edge">Edge OG endpoint</Link>
             <Link href="/og-node">Node OG endpoint</Link>
           </Sidebar>

--- a/examples/demo/tests/01-minimal/config.test.ts
+++ b/examples/demo/tests/01-minimal/config.test.ts
@@ -1,13 +1,12 @@
 import path from "node:path";
-import { vercelOutputConfigSchema } from "../../../../packages/vercel/src/schemas/config/config";
 import { expect, it } from "vitest";
+import { vercelOutputConfigSchema } from "../../../../packages/vercel/src/schemas/config/config";
 import { prepareTestJsonFileContent, testSchema } from "../common/helpers";
 
 prepareTestJsonFileContent(path.basename(__dirname), "config.json", (context) => {
   testSchema(context, vercelOutputConfigSchema);
 
   it("should have defaults routes only", () => {
-    console.log(context.file);
     expect(context.file).toHaveProperty("routes", [
       {
         src: "^/api/page$",

--- a/examples/demo/tests/05-vike/config.test.ts
+++ b/examples/demo/tests/05-vike/config.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, describe, expect, it } from "vitest";
+import { expect, it } from "vitest";
 import { vercelOutputConfigSchema } from "../../../../packages/vercel/src/schemas/config/config";
 import { testSchema } from "../common/helpers";
 import { prepareTestJsonFileContent } from "./utils";
@@ -37,6 +37,11 @@ prepareTestJsonFileContent("config.json", (context) => {
       {
         src: "^/og-edge(?:/((?:[^/]+?)(?:/(?:[^/]+?))*))?$",
         dest: "/og-edge/$1",
+        check: true,
+      },
+      {
+        src: "^(/vike-edge(?:/index\\.pageContext\\.json)?)$",
+        dest: expect.stringMatching("/pages/vike-edge-edge-([^/]+?)/\\?__original_path=\\$1"),
         check: true,
       },
       {

--- a/examples/demo/tests/05-vike/fs.test.ts
+++ b/examples/demo/tests/05-vike/fs.test.ts
@@ -63,6 +63,9 @@ describe("fs", () => {
     /\/functions\/pages\/named-([^\/]+?)\.prerender-config\.json/,
     /\/functions\/pages\/named-([^\/]+?)\.func\/index\.mjs/,
     /\/functions\/pages\/named-([^\/]+?)\.func\/\.vc-config\.json/,
+    // vike-edge
+    /\/functions\/pages\/vike-edge-edge-([^\/]+?)\.func\/index\.js/,
+    /\/functions\/pages\/vike-edge-edge-([^\/]+?)\.func\/\.vc-config\.json/,
     ...generatedFiles.map((f) => `/static/${f}`),
   ];
 

--- a/examples/demo/tests/05-vike/vite.config._test_.js
+++ b/examples/demo/tests/05-vike/vite.config._test_.js
@@ -21,7 +21,7 @@ export default {
         source: "endpoints/edge.ts",
         destination: "edge",
         edge: true,
-        addRoute: true,
+        route: true,
       },
     ],
     expiration: 25,

--- a/examples/demo/tests/common/utils.ts
+++ b/examples/demo/tests/common/utils.ts
@@ -1,6 +1,6 @@
 import os from "node:os";
 import path from "node:path";
-import { build, type InlineConfig } from "vite";
+import { type InlineConfig, build } from "vite";
 
 export function getTmpDir(displayName: string) {
   return path.join(os.tmpdir(), `vpv-demo-${displayName}`);
@@ -36,7 +36,7 @@ export async function callBuild(dirname: string, config: InlineConfig) {
         {
           source: "endpoints/edge.ts",
           destination: "edge",
-          addRoute: true,
+          route: true,
         },
         ...(config.vercel?.additionalEndpoints ?? []),
       ],

--- a/examples/demo/vite.config.ts
+++ b/examples/demo/vite.config.ts
@@ -1,7 +1,7 @@
 import react from "@vitejs/plugin-react-swc";
 import ssr from "vike/plugin";
-import vercel from "vite-plugin-vercel";
 import type { UserConfig } from "vite";
+import vercel from "vite-plugin-vercel";
 
 export default {
   plugins: [
@@ -17,17 +17,17 @@ export default {
       {
         source: "endpoints/edge.ts",
         destination: "edge",
-        addRoute: true,
+        route: true,
       },
       {
         source: "endpoints/og-node.tsx",
         destination: "og-node",
-        addRoute: true,
+        route: true,
       },
       {
         source: "endpoints/og-edge.tsx",
         destination: "og-edge",
-        addRoute: true,
+        route: true,
       },
     ],
   },

--- a/examples/express/vite.config.ts
+++ b/examples/express/vite.config.ts
@@ -20,7 +20,7 @@ export default {
         // replaces default Vike target
         destination: "ssr_",
         // already added by default Vike route
-        addRoute: false,
+        route: false,
       },
     ],
   },

--- a/packages/vercel/package.json
+++ b/packages/vercel/package.json
@@ -10,9 +10,9 @@
   "module": "./dist/index.js",
   "exports": {
     ".": {
+      "types": "./index.d.ts",
       "import": "./dist/index.js",
-      "require": "./dist/index.cjs",
-      "types": "./index.d.ts"
+      "require": "./dist/index.cjs"
     },
     "./types": {
       "types": "./index.d.ts"

--- a/packages/vercel/src/build.ts
+++ b/packages/vercel/src/build.ts
@@ -355,6 +355,13 @@ export async function buildEndpoints(resolvedConfig: ResolvedConfig): Promise<{
           );
         }
 
+        if (
+          (entry.isr !== undefined || exports.isr !== undefined) &&
+          (entry.edge !== undefined || exports.edge !== undefined)
+        ) {
+          throw new Error(`isr cannot be enabled for edge functions ('${entry.source}')`);
+        }
+
         if (exports.isr) {
           entry.isr = exports.isr;
         }

--- a/packages/vercel/src/types.ts
+++ b/packages/vercel/src/types.ts
@@ -145,10 +145,15 @@ export interface ViteVercelApiEntry {
    */
   buildOptions?: BuildOptions;
   /**
-   * Automatically add a route for the function (mimics defaults Vercel behavior)
-   * Set to `false` to disable
+   * @deprecated use `route` instead
    */
   addRoute?: boolean;
+  /**
+   * If `true`, guesses route for the function, and adds it to config.json (mimics defaults Vercel behavior).
+   * If a string is provided, it will be equivalent to a `rewrites` rule.
+   * Set to `false` to disable
+   */
+  route?: string | boolean;
   /**
    * Set to `true` to mark this function as an Edge Function
    */

--- a/packages/vercel/src/types.ts
+++ b/packages/vercel/src/types.ts
@@ -10,6 +10,8 @@ export type { VercelOutputConfig, VercelOutputVcConfig, VercelOutputPrerenderCon
 export type ViteVercelRewrite = Rewrite & { enforce?: "pre" | "post" };
 export type ViteVercelRedirect = Redirect & { enforce?: "pre" | "post" };
 
+export type Awaitable<T> = T | Promise<T>;
+
 // Vite config for Vercel
 
 export interface ViteVercelConfig {
@@ -72,7 +74,11 @@ export interface ViteVercelConfig {
    * }
    * ```
    */
-  additionalEndpoints?: ViteVercelApiEntry[];
+  additionalEndpoints?: (
+    | ViteVercelApiEntry
+    | (() => Awaitable<ViteVercelApiEntry>)
+    | (() => Awaitable<ViteVercelApiEntry[]>)
+  )[];
   /**
    * Advanced configuration to override .vercel/output/config.json
    * @see {@link https://vercel.com/docs/build-output-api/v3/configuration#configuration}
@@ -99,9 +105,7 @@ export interface ViteVercelConfig {
    *
    * @protected
    */
-  isr?:
-    | Record<string, VercelOutputIsr>
-    | (() => Promise<Record<string, VercelOutputIsr>> | Record<string, VercelOutputIsr>);
+  isr?: Record<string, VercelOutputIsr> | (() => Awaitable<Record<string, VercelOutputIsr>>);
   /**
    * Defaults to `.vercel/output`. Mostly useful for testing purpose
    * @protected
@@ -125,9 +129,7 @@ export interface VercelOutputIsr extends VercelOutputPrerenderConfig {
  * Keys are path relative to .vercel/output/static directory
  */
 export type ViteVercelPrerenderRoute = VercelOutputConfig["overrides"];
-export type ViteVercelPrerenderFn = (
-  resolvedConfig: ResolvedConfig,
-) => ViteVercelPrerenderRoute | Promise<ViteVercelPrerenderRoute>;
+export type ViteVercelPrerenderFn = (resolvedConfig: ResolvedConfig) => Awaitable<ViteVercelPrerenderRoute>;
 
 export interface ViteVercelApiEntry {
   /**

--- a/packages/vercel/src/types.ts
+++ b/packages/vercel/src/types.ts
@@ -1,9 +1,9 @@
-import type { ResolvedConfig } from "vite";
+import type { Redirect, Rewrite } from "@vercel/routing-utils";
 import type { BuildOptions, StdinOptions } from "esbuild";
+import type { ResolvedConfig } from "vite";
 import type { VercelOutputConfig } from "./schemas/config/config";
-import type { VercelOutputVcConfig } from "./schemas/config/vc-config";
 import type { VercelOutputPrerenderConfig } from "./schemas/config/prerender-config";
-import type { Rewrite, Redirect } from "@vercel/routing-utils";
+import type { VercelOutputVcConfig } from "./schemas/config/vc-config";
 
 export type { VercelOutputConfig, VercelOutputVcConfig, VercelOutputPrerenderConfig };
 
@@ -111,7 +111,7 @@ export interface ViteVercelConfig {
    * By default, Vite generates static files under `dist` folder.
    * But usually, when used through a Framework, such as Vike,
    * this folder can contain anything, requiring custom integration.
-   * Set this to false is you create a plugin for a Framework.
+   * Set this to false if you create a plugin for a Framework.
    */
   distContainsOnlyStatic?: boolean;
 }

--- a/packages/vike-integration/+config.ts
+++ b/packages/vike-integration/+config.ts
@@ -6,10 +6,10 @@ export default {
     isr: {
       env: { server: true },
     },
+    edge: {
+      env: { server: true },
+    },
     // TODO
-    // edge: {
-    //   env: { server: true },
-    // },
     // headers: {
     //   env: { server: true },
     // },

--- a/packages/vike-integration/config.d.ts
+++ b/packages/vike-integration/config.d.ts
@@ -7,8 +7,8 @@ declare global {
   namespace Vike {
     export interface Config {
       isr?: boolean | { expiration: number };
+      edge?: boolean;
       // TODO
-      // edge?: boolean;
       // headers?: Record<string, string>;
     }
   }

--- a/packages/vike-integration/package.json
+++ b/packages/vike-integration/package.json
@@ -31,6 +31,7 @@
   },
   "devDependencies": {
     "@types/node": "^18.19.45",
+    "@types/qs": "^6.9.15",
     "@vercel/node": "^3.2.8",
     "tsup": "^8.2.4",
     "typescript": "^5.5.4",
@@ -40,7 +41,8 @@
   },
   "dependencies": {
     "@brillout/libassert": "^0.5.8",
-    "nanoid": "^5.0.7"
+    "nanoid": "^5.0.7",
+    "qs": "^6.13.0"
   },
   "peerDependencies": {
     "vike": "^0.4.183",

--- a/packages/vike-integration/package.json
+++ b/packages/vike-integration/package.json
@@ -16,7 +16,8 @@
   "types": "./dist/vike.d.ts",
   "exports": {
     ".": "./dist/vike.js",
-    "./helpers": "./dist/templates/helpers.js",
+    "./helpers/node": "./dist/templates/node-helpers.js",
+    "./helpers/edge": "./dist/templates/edge-helpers.js",
     "./config": {
       "types": "./config.d.ts",
       "default": "./dist/+config.js"
@@ -32,6 +33,7 @@
   "devDependencies": {
     "@types/node": "^18.19.45",
     "@types/qs": "^6.9.15",
+    "@vercel/edge": "^1.1.2",
     "@vercel/node": "^3.2.8",
     "tsup": "^8.2.4",
     "typescript": "^5.5.4",

--- a/packages/vike-integration/templates/edge-helpers.ts
+++ b/packages/vike-integration/templates/edge-helpers.ts
@@ -49,12 +49,10 @@ export function getDefaultEmptyResponseHandler(): Response {
  * Send `httpResponse` through `response`
  */
 export function getDefaultResponseHandler(httpResponse: HttpResponse): Response {
-  const { statusCode, body, contentType } = httpResponse;
+  const { statusCode, body, headers } = httpResponse;
 
   return new Response(body, {
     status: statusCode,
-    headers: {
-      "content-type": contentType,
-    },
+    headers,
   });
 }

--- a/packages/vike-integration/templates/edge-helpers.ts
+++ b/packages/vike-integration/templates/edge-helpers.ts
@@ -26,7 +26,6 @@ export function getDefaultPageContextInit(request: Request) {
   );
 
   return {
-    url,
     urlOriginal: url,
     body: request.body,
     cookies,

--- a/packages/vike-integration/templates/edge-helpers.ts
+++ b/packages/vike-integration/templates/edge-helpers.ts
@@ -1,0 +1,60 @@
+import { parse } from "qs";
+import type { renderPage } from "vike";
+import { getOriginalUrl } from "./utils";
+
+type HttpResponse = NonNullable<Awaited<ReturnType<typeof renderPage>>["httpResponse"]>;
+
+/**
+ * Extract useful pageContext from request to give to renderPage(...).
+ * It handles internals such as retrieving the original url from `x-now-route-matches` header or from `__original_path` query,
+ * so it's highly recommended to use it instead of `request.url`.
+ * @param request
+ */
+export function getDefaultPageContextInit(request: Request) {
+  const queryString = new URL(request.url).search.slice(1); // Remove the leading "?" with .slice(1)
+  const query = parse(queryString);
+  const url = getOriginalUrl(request.headers.get("x-now-route-matches"), query.__original_path, request.url);
+  const cookieHeader = request.headers.get("Cookie") || "";
+
+  const cookies = cookieHeader.split("; ").reduce(
+    (acc, cookie) => {
+      const [name, value] = cookie.split("=");
+      acc[name] = value;
+      return acc;
+    },
+    {} as Record<string, string>,
+  );
+
+  return {
+    url,
+    urlOriginal: url,
+    body: request.body,
+    cookies,
+  };
+}
+
+/**
+ * Send a default empty HTML response
+ */
+export function getDefaultEmptyResponseHandler(): Response {
+  return new Response(null, {
+    status: 200,
+    headers: {
+      "content-type": "text/html; charset=UTF-8",
+    },
+  });
+}
+
+/**
+ * Send `httpResponse` through `response`
+ */
+export function getDefaultResponseHandler(httpResponse: HttpResponse): Response {
+  const { statusCode, body, contentType } = httpResponse;
+
+  return new Response(body, {
+    status: statusCode,
+    headers: {
+      "content-type": contentType,
+    },
+  });
+}

--- a/packages/vike-integration/templates/helpers.ts
+++ b/packages/vike-integration/templates/helpers.ts
@@ -1,5 +1,5 @@
-import { parse } from "node:querystring";
 import type { VercelRequest, VercelResponse } from "@vercel/node";
+import { parse } from "qs";
 import type { renderPage } from "vike";
 
 type HttpResponse = NonNullable<Awaited<ReturnType<typeof renderPage>>["httpResponse"]>;

--- a/packages/vike-integration/templates/node-helpers.ts
+++ b/packages/vike-integration/templates/node-helpers.ts
@@ -37,9 +37,11 @@ export function getDefaultEmptyResponseHandler(response: VercelResponse) {
  * @param httpResponse
  */
 export function getDefaultResponseHandler(response: VercelResponse, httpResponse: HttpResponse) {
-  const { statusCode, body, contentType } = httpResponse;
+  const { statusCode, body, headers } = httpResponse;
 
   response.statusCode = statusCode;
-  response.setHeader("content-type", contentType);
+  for (const [name, value] of headers) {
+    response.setHeader(name, value);
+  }
   return response.end(body);
 }

--- a/packages/vike-integration/templates/node-helpers.ts
+++ b/packages/vike-integration/templates/node-helpers.ts
@@ -1,6 +1,6 @@
 import type { VercelRequest, VercelResponse } from "@vercel/node";
-import { parse } from "qs";
 import type { renderPage } from "vike";
+import { getOriginalUrl } from "./utils";
 
 type HttpResponse = NonNullable<Awaited<ReturnType<typeof renderPage>>["httpResponse"]>;
 
@@ -12,15 +12,7 @@ type HttpResponse = NonNullable<Awaited<ReturnType<typeof renderPage>>["httpResp
  */
 export function getDefaultPageContextInit(request: VercelRequest) {
   const query: Record<string, string | string[]> = request.query ?? {};
-  const matches =
-    // FIXME x-now-route-matches is not definitive https://github.com/orgs/vercel/discussions/577#discussioncomment-2769478
-    typeof request.headers["x-now-route-matches"] === "string" ? parse(request.headers["x-now-route-matches"]) : null;
-  const url: string =
-    typeof query.__original_path === "string"
-      ? query.__original_path
-      : matches && typeof matches?.["1"] === "string"
-        ? matches["1"]
-        : request.url ?? "";
+  const url = getOriginalUrl(request.headers["x-now-route-matches"], query.__original_path, request.url);
   return {
     url,
     urlOriginal: url,

--- a/packages/vike-integration/templates/ssr_.template.ts
+++ b/packages/vike-integration/templates/ssr_.template.ts
@@ -1,6 +1,6 @@
 import type { VercelRequest, VercelResponse } from "@vercel/node";
 import { renderPage } from "vike/server";
-import { getDefaultEmptyResponseHandler, getDefaultPageContextInit, getDefaultResponseHandler } from "./helpers";
+import { getDefaultEmptyResponseHandler, getDefaultPageContextInit, getDefaultResponseHandler } from "./node-helpers";
 
 export default async function handler(request: VercelRequest, response: VercelResponse) {
   console.debug("query", request.query);

--- a/packages/vike-integration/templates/ssr_edge_.template.ts
+++ b/packages/vike-integration/templates/ssr_edge_.template.ts
@@ -1,0 +1,16 @@
+import { renderPage } from "vike/server";
+import { getDefaultEmptyResponseHandler, getDefaultPageContextInit, getDefaultResponseHandler } from "./edge-helpers";
+
+export default async function handler(request: Request): Promise<Response> {
+  console.debug("url", request.url);
+  console.debug("headers", request.headers);
+  const pageContextInit = getDefaultPageContextInit(request);
+  const pageContext = await renderPage(pageContextInit);
+  const { httpResponse } = pageContext;
+
+  if (!httpResponse) {
+    return getDefaultEmptyResponseHandler();
+  }
+
+  return getDefaultResponseHandler(httpResponse);
+}

--- a/packages/vike-integration/templates/utils.ts
+++ b/packages/vike-integration/templates/utils.ts
@@ -1,0 +1,12 @@
+import { parse } from "qs";
+
+export function getOriginalUrl(xNowRouteMatchesHeader: unknown, originalPath: unknown, url?: string) {
+  const matches =
+    // FIXME x-now-route-matches is not definitive https://github.com/orgs/vercel/discussions/577#discussioncomment-2769478
+    typeof xNowRouteMatchesHeader === "string" ? parse(xNowRouteMatchesHeader) : null;
+  return typeof originalPath === "string"
+    ? originalPath
+    : matches && typeof matches?.["1"] === "string"
+      ? matches["1"]
+      : url ?? "";
+}

--- a/packages/vike-integration/tsup.config.ts
+++ b/packages/vike-integration/tsup.config.ts
@@ -1,18 +1,18 @@
-import { defineConfig } from "tsup";
-import { rename } from "node:fs/promises";
 import { existsSync } from "node:fs";
+import { rename } from "node:fs/promises";
+import { defineConfig } from "tsup";
 
 export default defineConfig([
   {
     clean: true,
-    entry: ["./vike.ts", "./templates/helpers.ts", "./+config.ts"],
+    entry: ["./vike.ts", "./templates/node-helpers.ts", "./templates/edge-helpers.ts", "./+config.ts"],
     external: ["esbuild", "rollup", "vite", "vike"],
     format: ["esm"],
 
     platform: "node",
     target: "node18",
     dts: {
-      entry: ["./vike.ts", "./templates/helpers.ts", "./+config.ts"],
+      entry: ["./vike.ts", "./templates/node-helpers.ts", "./templates/edge-helpers.ts", "./+config.ts"],
     },
     async onSuccess() {
       // rollup-plugin-dts chooses to rename things its way

--- a/packages/vike-integration/vike.ts
+++ b/packages/vike-integration/vike.ts
@@ -241,6 +241,27 @@ function getRouteFsRoute(pageRoutes: PageRoutes, pageId: string) {
   return null;
 }
 
+export async function getSsrEdgeEndpoint(): Promise<ViteVercelApiEntry["source"]> {
+  const sourcefile = path.join(__dirname, "..", "templates", "ssr_edge_.template.ts");
+  const contents = await fs.readFile(sourcefile, "utf-8");
+  const resolveDir = path.dirname(sourcefile);
+
+  return {
+    contents: contents,
+    sourcefile,
+    loader: sourcefile.endsWith(".ts")
+      ? "ts"
+      : sourcefile.endsWith(".tsx")
+        ? "tsx"
+        : sourcefile.endsWith(".js")
+          ? "js"
+          : sourcefile.endsWith(".jsx")
+            ? "jsx"
+            : "default",
+    resolveDir,
+  };
+}
+
 export async function getSsrEndpoint(source?: string) {
   const sourcefile = source ?? path.join(__dirname, "..", "templates", "ssr_.template.ts");
   const contents = await fs.readFile(sourcefile, "utf-8");
@@ -423,7 +444,7 @@ export function vitePluginVercelVikeConfigPlugin(): Plugin {
         );
       }
 
-      const edgeSource = (await getSsrEndpoint()).source;
+      const edgeSource = await getSsrEdgeEndpoint();
 
       return {
         vercel: {

--- a/packages/vike-integration/vike.ts
+++ b/packages/vike-integration/vike.ts
@@ -262,7 +262,7 @@ export async function getSsrEndpoint(source?: string) {
       resolveDir,
     },
     destination: rendererDestination,
-    addRoute: false,
+    route: false,
   } satisfies ViteVercelApiEntry;
 }
 
@@ -433,16 +433,20 @@ export function vitePluginVercelVikeConfigPlugin(): Plugin {
 
               return pagesWithConfigs
                 .filter((page) => {
-                  return typeof page.edge === "boolean";
+                  return page.edge === true;
                 })
                 .map((page) => {
+                  if (!page.route) {
+                    console.warn(
+                      `Page ${page._pageId}: edge is not supported when using route function. Remove \`{ edge }\` export or use a route string if possible.`,
+                    );
+                  }
                   const destination = `${page._pageId.replace(/\/index$/g, "")}-edge-${nanoid()}`;
                   return {
                     source: edgeSource,
                     destination,
-                    addRoute: true,
-                    // biome-ignore lint/style/noNonNullAssertion: filtered
-                    edge: page.edge!,
+                    route: page.route ? `${page.route}(?:\\/index\\.pageContext\\.json)?` : undefined,
+                    edge: true,
                   };
                 });
             },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -232,6 +232,9 @@ importers:
       '@types/qs':
         specifier: ^6.9.15
         version: 6.9.15
+      '@vercel/edge':
+        specifier: ^1.1.2
+        version: 1.1.2
       '@vercel/node':
         specifier: ^3.2.8
         version: 3.2.8(@swc/core@1.7.14)
@@ -1100,6 +1103,9 @@ packages:
     peerDependenciesMeta:
       '@opentelemetry/api':
         optional: true
+
+  '@vercel/edge@1.1.2':
+    resolution: {integrity: sha512-wt5SnhsMahWX8U9ZZhFUQoiXhMn/CUxA5xeMdZX1cwyOL1ZbDR3rNI8HRT9RSU73nDxeF6jlnqJyp/0Jy0VM2A==}
 
   '@vercel/error-utils@2.0.2':
     resolution: {integrity: sha512-Sj0LFafGpYr6pfCqrQ82X6ukRl5qpmVrHM/191kNYFqkkB9YkjlMAj6QcEsvCG259x4QZ7Tya++0AB85NDPbKQ==}
@@ -3991,6 +3997,8 @@ snapshots:
   '@vercel/edge-config@1.2.1':
     dependencies:
       '@vercel/edge-config-fs': 0.1.0
+
+  '@vercel/edge@1.1.2': {}
 
   '@vercel/error-utils@2.0.2': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -222,10 +222,16 @@ importers:
       nanoid:
         specifier: ^5.0.7
         version: 5.0.7
+      qs:
+        specifier: ^6.13.0
+        version: 6.13.0
     devDependencies:
       '@types/node':
         specifier: ^18.19.45
         version: 18.19.45
+      '@types/qs':
+        specifier: ^6.9.15
+        version: 6.9.15
       '@vercel/node':
         specifier: ^3.2.8
         version: 3.2.8(@swc/core@1.7.14)
@@ -2595,6 +2601,10 @@ packages:
 
   qs@6.11.0:
     resolution: {integrity: sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==}
+    engines: {node: '>=0.6'}
+
+  qs@6.13.0:
+    resolution: {integrity: sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==}
     engines: {node: '>=0.6'}
 
   queue-microtask@1.2.3:
@@ -5693,6 +5703,10 @@ snapshots:
   punycode@2.3.1: {}
 
   qs@6.11.0:
+    dependencies:
+      side-channel: 1.0.6
+
+  qs@6.13.0:
     dependencies:
       side-channel: 1.0.6
 


### PR DESCRIPTION
Vike projects can now leverage `+config.ts` to target edge environment:
```ts
// /pages/+config.ts
import type { Config } from "vike/types";

export default {
  edge: true,
} satisfies Config;
```