### PR TITLE
fix: pass endpoint buildOptions to esbuild

### DIFF
--- a/packages/vercel/src/build.ts
+++ b/packages/vercel/src/build.ts
@@ -384,7 +384,7 @@ export async function buildEndpoints(resolvedConfig: ResolvedConfig): Promise<{
       }
     }
 
-    await buildFn(resolvedConfig, entry);
+    await buildFn(resolvedConfig, entry, entry.buildOptions);
   }
 
   const isrEntries = entries


### PR DESCRIPTION
Hi,

type `ViteVercelApiEntry` is indicating that endpoint `buildOptions` can be given as options, but it was never used inside the plugin.