### PR TITLE
fix: allow catch-all routes with [...catchAll] syntax

### DIFF
--- a/examples/simple/_api/[...catchAll].ts
+++ b/examples/simple/_api/[...catchAll].ts
@@ -1,0 +1,5 @@
+import type { VercelRequest, VercelResponse } from "@vercel/node";
+
+export default async function handler(request: VercelRequest, response: VercelResponse) {
+  return response.send("OK");
+}

--- a/examples/simple/_api/[[...optionalCatchAll]].ts
+++ b/examples/simple/_api/[[...optionalCatchAll]].ts
@@ -1,0 +1,5 @@
+import type { VercelRequest, VercelResponse } from "@vercel/node";
+
+export default async function handler(request: VercelRequest, response: VercelResponse) {
+  return response.send("OK");
+}

--- a/packages/vercel/src/config.ts
+++ b/packages/vercel/src/config.ts
@@ -33,10 +33,18 @@ export function getConfig(
     ...(rewrites ?? []),
   ];
 
+  const _enforcedRewrites = reorderEnforce(_rewrites)
+    .map(r => {
+      // :...catchAll -> :catchAll+ (global)
+      r.source = r.source.replaceAll(/:(\.\.\.)(.*)/g, ":$2+");
+
+      return r
+    });
+
   const { routes, error } = getTransformedRoutes({
     cleanUrls: resolvedConfig.vercel?.cleanUrls ?? true,
     trailingSlash: resolvedConfig.vercel?.trailingSlash,
-    rewrites: reorderEnforce(_rewrites),
+    rewrites: _enforcedRewrites,
     redirects: resolvedConfig.vercel?.redirects ? reorderEnforce(resolvedConfig.vercel?.redirects) : undefined,
     headers,
   });
@@ -52,8 +60,8 @@ export function getConfig(
   ) {
     console.warn(
       'Did you forget to add `"continue": true` to your routes? See https://vercel.com/docs/build-output-api/v3/configuration#source-route\n' +
-        "If not, it is discouraged to use `vercel.config.routes` to override routes. " +
-        "Prefer using `vercel.rewrites` and `vercel.redirects`.",
+      "If not, it is discouraged to use `vercel.config.routes` to override routes. " +
+      "Prefer using `vercel.rewrites` and `vercel.redirects`.",
     );
   }
 

--- a/packages/vercel/src/config.ts
+++ b/packages/vercel/src/config.ts
@@ -35,6 +35,11 @@ export function getConfig(
 
   const _enforcedRewrites = reorderEnforce(_rewrites)
     .map(r => {
+      // optional catch-all
+      // :[...optionalCatchAll] -> :catchAll* (global)
+      r.source = r.source.replaceAll(/:\[(\.\.\.)(.*)\]/g, ":$2*");
+
+      // catch-all
       // :...catchAll -> :catchAll+ (global)
       r.source = r.source.replaceAll(/:(\.\.\.)(.*)/g, ":$2+");
 


### PR DESCRIPTION
when building a route like `api/[...catchAll]` we get an error from `@vercel/routing-utils`, as it gets transformed to `api/:...catchAll` which is not valid.

To my knowledge, there was no other way go have catch-all routes without using vike.

This PR attempts to fix that by applying a regex transform.

- [x] Could be further extended by considering the optional catch-all syntax (`[[...optionalCatchAll]]`).
