### PR TITLE
chore: bump photon and vike

### DIFF
--- a/examples/demo/package.json
+++ b/examples/demo/package.json
@@ -42,7 +42,7 @@
     "@vite-plugin-vercel/schemas": "workspace:^",
     "fast-glob": "^3.3.3",
     "playwright": "^1.54.1",
-    "vike-server": "1.0.23-commit-79e7a14",
+    "vike-server": "1.0.23-commit-52c7d04",
     "vitest": "^3.2.4",
     "zod": "^4.0.14"
   }

--- a/examples/demo/package.json
+++ b/examples/demo/package.json
@@ -25,7 +25,7 @@
     "vike": "^0.4.236",
     "vike-react": "^0.6.5",
     "vike-vercel": "workspace:^",
-    "vite": "^7.0.6",
+    "vite": "^7.1.3",
     "vite-plugin-vercel": "workspace:^"
   },
   "type": "module",
@@ -42,7 +42,7 @@
     "@vite-plugin-vercel/schemas": "workspace:^",
     "fast-glob": "^3.3.3",
     "playwright": "^1.54.1",
-    "vike-server": "1.0.16-commit-91ea469",
+    "vike-server": "1.0.23-commit-79e7a14",
     "vitest": "^3.2.4",
     "zod": "^4.0.14"
   }

--- a/examples/demo/tests/01-vike/fs.test.ts
+++ b/examples/demo/tests/01-vike/fs.test.ts
@@ -61,7 +61,7 @@ describe("fs", () => {
     "/static/static/index.pageContext.json",
     "/static/test.html",
     ...generatedFiles.map((f) => `/static/${f}`),
-    "/static/_temp_manifest.json",
+    "/static/.vite/manifest.json",
   ];
 
   it("should generate the right files", async () => {

--- a/examples/hono/package.json
+++ b/examples/hono/package.json
@@ -17,10 +17,10 @@
     "cross-env": "^10.0.0",
     "hono": "^4.8.10",
     "typescript": "^5.8.3",
-    "vite": "^7.0.6"
+    "vite": "^7.1.3"
   },
   "dependencies": {
-    "@photonjs/core": "0.0.1-commit-877032a",
+    "@photonjs/core": "^0.0.3",
     "vite-plugin-vercel": "workspace:*"
   }
 }

--- a/examples/simple/package.json
+++ b/examples/simple/package.json
@@ -15,7 +15,7 @@
     "@types/node": "^20.19.9",
     "@vercel/node": "^5.3.7",
     "typescript": "^5.8.3",
-    "vite": "^7.0.6"
+    "vite": "^7.1.3"
   },
   "dependencies": {
     "hono": "^4.8.10",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "pnpm": {
     "overrides": {
       "path-to-regexp@>=4.0.0 <6.3.0": "^6.3.0",
-      "vike": "0.4.237-commit-e549c30",
+      "vike": "0.4.237-commit-fd8294f",
       "vite": "^7.1.3"
     }
   }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "pnpm": {
     "overrides": {
       "path-to-regexp@>=4.0.0 <6.3.0": "^6.3.0",
-      "vike": "0.4.237-commit-2d6f480",
+      "vike": "0.4.237-commit-2c1db32",
       "vite": "^7.1.3"
     }
   }

--- a/package.json
+++ b/package.json
@@ -29,10 +29,9 @@
   },
   "pnpm": {
     "overrides": {
-      "@photonjs/core": "0.0.1-commit-877032a",
       "path-to-regexp@>=4.0.0 <6.3.0": "^6.3.0",
-      "vike": "^0.4.236",
-      "vite": "^7.0.6"
+      "vike": "0.4.237-commit-e549c30",
+      "vite": "^7.1.3"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "pnpm": {
     "overrides": {
       "path-to-regexp@>=4.0.0 <6.3.0": "^6.3.0",
-      "vike": "0.4.237-commit-fd8294f",
+      "vike": "0.4.237-commit-2d6f480",
       "vite": "^7.1.3"
     }
   }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "pnpm": {
     "overrides": {
       "path-to-regexp@>=4.0.0 <6.3.0": "^6.3.0",
-      "vike": "0.4.237-commit-2c1db32",
+      "vike": "0.4.237-commit-cc7f0f6",
       "vite": "^7.1.3"
     }
   }

--- a/packages/vercel/package.json
+++ b/packages/vercel/package.json
@@ -37,12 +37,12 @@
     "rollup": "^4.46.2",
     "tsup": "^8.5.0",
     "typescript": "^5.8.3",
-    "vite": "^7.0.6"
+    "vite": "^7.1.3"
   },
   "dependencies": {
     "@brillout/libassert": "^0.5.8",
     "@manypkg/find-root": "^3.1.0",
-    "@photonjs/core": "0.0.1-commit-877032a",
+    "@photonjs/core": "^0.0.3",
     "@universal-middleware/core": "^0.4.9",
     "@universal-middleware/vercel": "^0.4.20",
     "@vercel/build-utils": "^11.0.0",

--- a/packages/vercel/src/plugins/bundle.ts
+++ b/packages/vercel/src/plugins/bundle.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { copyFile, mkdir, rm } from "node:fs/promises";
+import { builtinModules } from "node:module";
 import path from "node:path";
 import { findRoot } from "@manypkg/find-root";
 import { nodeFileTrace } from "@vercel/nft";
@@ -8,10 +9,9 @@ import type { Environment, Plugin } from "vite";
 import { getVercelAPI, type ViteVercelOutFile, type ViteVercelOutFileChunk } from "../api";
 import { joinAbsolute, joinAbsolutePosix } from "../helpers";
 import type { ViteVercelConfig } from "../types";
+import { edgeConditions } from "../utils/edge";
 import { isVercelLastBuildStep } from "../utils/env";
 import { edgeExternal } from "../utils/external";
-import { edgeConditions } from "../utils/edge";
-import { builtinModules } from "node:module";
 
 const builtIns = new Set(builtinModules.flatMap((m) => [m, `node:${m}`]));
 

--- a/packages/vercel/src/plugins/bundle.ts
+++ b/packages/vercel/src/plugins/bundle.ts
@@ -125,8 +125,7 @@ export function bundlePlugin(pluginConfig: ViteVercelConfig): Plugin[] {
 
 function getAbsoluteOutFileWithout_tmp(outfile: ViteVercelOutFile) {
   const source = joinAbsolutePosix(outfile.root, outfile.outdir, outfile.filepath);
-  // effectively removes appended _tmp folder
-  const destination = source.replace(outfile.outdir, path.dirname(outfile.outdir));
+  const destination = source.replace(outfile.outdir, outfile.outdir.replace(/_tmp(\/|\\|$)/, ""));
   return {
     source,
     destination,

--- a/packages/vike/package.json
+++ b/packages/vike/package.json
@@ -39,5 +39,8 @@
     "@photonjs/core": "^0.0.3",
     "vike": "^0.4.236",
     "vike-server": "1.0.23-commit-52c7d04"
+  },
+  "engines": {
+    "node": ">=20.19.0 || >=22.12.0"
   }
 }

--- a/packages/vike/package.json
+++ b/packages/vike/package.json
@@ -38,6 +38,6 @@
     "@brillout/libassert": "^0.5.8",
     "@photonjs/core": "^0.0.3",
     "vike": "^0.4.236",
-    "vike-server": "1.0.23-commit-79e7a14"
+    "vike-server": "1.0.23-commit-52c7d04"
   }
 }

--- a/packages/vike/package.json
+++ b/packages/vike/package.json
@@ -31,13 +31,13 @@
     "@universal-middleware/core": "^0.4.9",
     "tsup": "^8.5.0",
     "typescript": "^5.8.3",
-    "vite": "^7.0.6",
+    "vite": "^7.1.3",
     "vite-plugin-vercel": "workspace:^"
   },
   "dependencies": {
     "@brillout/libassert": "^0.5.8",
-    "@photonjs/core": "0.0.1-commit-877032a",
+    "@photonjs/core": "^0.0.3",
     "vike": "^0.4.236",
-    "vike-server": "1.0.16-commit-91ea469"
+    "vike-server": "1.0.23-commit-79e7a14"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,10 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  '@photonjs/core': 0.0.1-commit-877032a
   path-to-regexp@>=4.0.0 <6.3.0: ^6.3.0
-  vike: ^0.4.236
-  vite: ^7.0.6
+  vike: 0.4.237-commit-e549c30
+  vite: ^7.1.3
 
 importers:
 
@@ -52,7 +51,7 @@ importers:
         version: 0.7.2
       '@vitejs/plugin-react':
         specifier: ^4.7.0
-        version: 4.7.0(vite@7.0.6(@types/node@20.19.9))
+        version: 4.7.0(vite@7.1.3(@types/node@20.19.9))
       cross-fetch:
         specifier: ^4.1.0
         version: 4.1.0
@@ -69,17 +68,17 @@ importers:
         specifier: ^5.8.3
         version: 5.8.3
       vike:
-        specifier: ^0.4.236
-        version: 0.4.236(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.0.6(@types/node@20.19.9))
+        specifier: 0.4.237-commit-e549c30
+        version: 0.4.237-commit-e549c30(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.3(@types/node@20.19.9))
       vike-react:
         specifier: ^0.6.5
-        version: 0.6.5(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(vike@0.4.236(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.0.6(@types/node@20.19.9)))
+        version: 0.6.5(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(vike@0.4.237-commit-e549c30(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.3(@types/node@20.19.9)))
       vike-vercel:
         specifier: workspace:^
         version: link:../../packages/vike
       vite:
-        specifier: ^7.0.6
-        version: 7.0.6(@types/node@20.19.9)
+        specifier: ^7.1.3
+        version: 7.1.3(@types/node@20.19.9)
       vite-plugin-vercel:
         specifier: workspace:^
         version: link:../../packages/vercel
@@ -104,7 +103,7 @@ importers:
         version: 19.1.7(@types/react@19.1.9)
       '@universal-middleware/core':
         specifier: ^0.4.9
-        version: 0.4.9(hono@4.8.10)
+        version: 0.4.9(hono@4.9.4)
       '@vercel/node':
         specifier: ^5.3.7
         version: 5.3.7(rollup@4.46.2)
@@ -118,8 +117,8 @@ importers:
         specifier: ^1.54.1
         version: 1.54.1
       vike-server:
-        specifier: 1.0.16-commit-91ea469
-        version: 1.0.16-commit-91ea469(hono@4.8.10)(vike@0.4.236(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.0.6(@types/node@20.19.9)))(vite@7.0.6(@types/node@20.19.9))
+        specifier: 1.0.23-commit-79e7a14
+        version: 1.0.23-commit-79e7a14(hono@4.9.4)(vike@0.4.237-commit-e549c30(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.3(@types/node@20.19.9)))(vite@7.1.3(@types/node@20.19.9))
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@20.19.9)
@@ -130,8 +129,8 @@ importers:
   examples/hono:
     dependencies:
       '@photonjs/core':
-        specifier: 0.0.1-commit-877032a
-        version: 0.0.1-commit-877032a(vite@7.0.6(@types/node@20.19.9))
+        specifier: ^0.0.3
+        version: 0.0.3(vite@7.1.3(@types/node@20.19.9))
       vite-plugin-vercel:
         specifier: workspace:*
         version: link:../../packages/vercel
@@ -144,19 +143,19 @@ importers:
         version: 10.0.0
       hono:
         specifier: ^4.8.10
-        version: 4.8.10
+        version: 4.9.4
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
       vite:
-        specifier: ^7.0.6
-        version: 7.0.6(@types/node@20.19.9)
+        specifier: ^7.1.3
+        version: 7.1.3(@types/node@20.19.9)
 
   examples/simple:
     dependencies:
       hono:
         specifier: ^4.8.10
-        version: 4.8.10
+        version: 4.9.4
       vite-plugin-vercel:
         specifier: workspace:*
         version: link:../../packages/vercel
@@ -171,8 +170,8 @@ importers:
         specifier: ^5.8.3
         version: 5.8.3
       vite:
-        specifier: ^7.0.6
-        version: 7.0.6(@types/node@20.19.9)
+        specifier: ^7.1.3
+        version: 7.1.3(@types/node@20.19.9)
 
   packages/schemas:
     dependencies:
@@ -199,14 +198,14 @@ importers:
         specifier: ^3.1.0
         version: 3.1.0
       '@photonjs/core':
-        specifier: 0.0.1-commit-877032a
-        version: 0.0.1-commit-877032a(vite@7.0.6(@types/node@20.19.9))
+        specifier: ^0.0.3
+        version: 0.0.3(vite@7.1.3(@types/node@20.19.9))
       '@universal-middleware/core':
         specifier: ^0.4.9
-        version: 0.4.9(hono@4.8.10)
+        version: 0.4.9(hono@4.9.4)
       '@universal-middleware/vercel':
         specifier: ^0.4.20
-        version: 0.4.20(@universal-middleware/h3@0.4.12(hono@4.8.10))(hono@4.8.10)
+        version: 0.4.20(@universal-middleware/h3@0.4.12(hono@4.9.4))(hono@4.9.4)
       '@vercel/build-utils':
         specifier: ^11.0.0
         version: 11.0.0
@@ -239,14 +238,14 @@ importers:
         version: 7.1.0
       vite-plugin-wasm:
         specifier: ^3.5.0
-        version: 3.5.0(vite@7.0.6(@types/node@20.19.9))
+        version: 3.5.0(vite@7.1.3(@types/node@20.19.9))
     devDependencies:
       '@types/node':
         specifier: ^20.19.9
         version: 20.19.9
       '@universal-middleware/express':
         specifier: ^0.4.19
-        version: 0.4.19(hono@4.8.10)
+        version: 0.4.19(hono@4.9.4)
       '@vercel/node':
         specifier: ^5.3.7
         version: 5.3.7(rollup@4.46.2)
@@ -260,8 +259,8 @@ importers:
         specifier: ^5.8.3
         version: 5.8.3
       vite:
-        specifier: ^7.0.6
-        version: 7.0.6(@types/node@20.19.9)
+        specifier: ^7.1.3
+        version: 7.1.3(@types/node@20.19.9)
 
   packages/vike:
     dependencies:
@@ -269,21 +268,21 @@ importers:
         specifier: ^0.5.8
         version: 0.5.8
       '@photonjs/core':
-        specifier: 0.0.1-commit-877032a
-        version: 0.0.1-commit-877032a(vite@7.0.6(@types/node@20.19.9))
+        specifier: ^0.0.3
+        version: 0.0.3(vite@7.1.3(@types/node@20.19.9))
       vike:
-        specifier: ^0.4.236
-        version: 0.4.236(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.0.6(@types/node@20.19.9))
+        specifier: 0.4.237-commit-e549c30
+        version: 0.4.237-commit-e549c30(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.3(@types/node@20.19.9))
       vike-server:
-        specifier: 1.0.16-commit-91ea469
-        version: 1.0.16-commit-91ea469(hono@4.8.10)(vike@0.4.236(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.0.6(@types/node@20.19.9)))(vite@7.0.6(@types/node@20.19.9))
+        specifier: 1.0.23-commit-79e7a14
+        version: 1.0.23-commit-79e7a14(hono@4.9.4)(vike@0.4.237-commit-e549c30(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.3(@types/node@20.19.9)))(vite@7.1.3(@types/node@20.19.9))
     devDependencies:
       '@types/node':
         specifier: ^20.19.9
         version: 20.19.9
       '@universal-middleware/core':
         specifier: ^0.4.9
-        version: 0.4.9(hono@4.8.10)
+        version: 0.4.9(hono@4.9.4)
       tsup:
         specifier: ^8.5.0
         version: 8.5.0(postcss@8.5.6)(typescript@5.8.3)
@@ -291,8 +290,8 @@ importers:
         specifier: ^5.8.3
         version: 5.8.3
       vite:
-        specifier: ^7.0.6
-        version: 7.0.6(@types/node@20.19.9)
+        specifier: ^7.1.3
+        version: 7.1.3(@types/node@20.19.9)
       vite-plugin-vercel:
         specifier: workspace:^
         version: link:../vercel
@@ -468,8 +467,8 @@ packages:
   '@brillout/import@0.2.6':
     resolution: {integrity: sha512-1GUTmADc8trUC1YSW2lp9r6PmwluMoEyHajnE1kxVdbKGD0wJOlq/DvTWMUqLtBDCnQR+n//qgMtz6HwA/lotA==}
 
-  '@brillout/json-serializer@0.5.16':
-    resolution: {integrity: sha512-X9CujUMruFxH35cyFgzebg3biBBRz4ouMmjJZwIa04D188du0V47QFcIK7YXKl3z0pue+9NccQ+1zaxhB49r1Q==}
+  '@brillout/json-serializer@0.5.20':
+    resolution: {integrity: sha512-RjRm7siy3VEB248gYudtWB4FZyoIL4kuA/HF3mM4ViAd1LT6Tl9eZsp5n0/hB5uM/C9JKICCNsJ6slNGgjdetA==}
 
   '@brillout/libassert@0.5.8':
     resolution: {integrity: sha512-u/fu+jTRUdNdbLONGq1plCfh+k2/XjSbGVTfnF3rHnSPZd+ABWp0XinR5ifrFkyGOzMbzv8IiQ44lZ4U6ZGrGA==}
@@ -794,10 +793,10 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@photonjs/core@0.0.1-commit-877032a':
-    resolution: {integrity: sha512-Izb8HeqJVziU3X0xD/grkw0BaITPiqTxMPld9vHcn9mdlcVnhuVePjmCtiHq1V3ayfq0gXmh62q1WBHQByq2Eg==}
+  '@photonjs/core@0.0.3':
+    resolution: {integrity: sha512-kjnsxtvgXBP6j0lxzJwGNGSSbzNvosICpooG9ntYqu649XNoA3uyiFs3F5X39BegM7Yv6oZGHoKSXbNi2JuSQQ==}
     peerDependencies:
-      vite: ^7.0.6
+      vite: ^7.1.3
     peerDependenciesMeta:
       vite:
         optional: true
@@ -1145,7 +1144,7 @@ packages:
     resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
-      vite: ^7.0.6
+      vite: ^7.1.3
 
   '@vitest/expect@3.2.4':
     resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
@@ -1154,7 +1153,7 @@ packages:
     resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
     peerDependencies:
       msw: ^2.4.9
-      vite: ^7.0.6
+      vite: ^7.1.3
     peerDependenciesMeta:
       msw:
         optional: true
@@ -1761,8 +1760,9 @@ packages:
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
 
-  fdir@6.4.6:
-    resolution: {integrity: sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==}
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
     peerDependencies:
       picomatch: ^3 || ^4
     peerDependenciesMeta:
@@ -1879,8 +1879,8 @@ packages:
     resolution: {integrity: sha512-Ox1pJVrDCyGHMG9CFg1tmrRUMRPRsAWYc/PinY0XzJU4K7y7vjNoLKIQ7BR5UJMCxNN8EM1MNDmHWA/B3aZUuw==}
     engines: {node: '>=6'}
 
-  hono@4.8.10:
-    resolution: {integrity: sha512-DRMYbR3aFk6YET1FCSAFbgF2cWYTz5j0YAFYPECx9fmrbKBDAYnWU+YCgRTpOaatxMYN6e68U/2IG39zRP4W/A==}
+  hono@4.9.4:
+    resolution: {integrity: sha512-61hl6MF6ojTl/8QSRu5ran6GXt+6zsngIUN95KzF5v5UjiX/xnrLR358BNRawwIRO49JwUqJqQe3Rb2v559R8Q==}
     engines: {node: '>=16.9.0'}
 
   http-errors@2.0.0:
@@ -2857,24 +2857,24 @@ packages:
     peerDependencies:
       react: '>=19'
       react-dom: '>=19'
-      vike: ^0.4.236
+      vike: 0.4.237-commit-e549c30
 
-  vike-server@1.0.16-commit-91ea469:
-    resolution: {integrity: sha512-lBKFJXWq0vpLsl2s8oIgHo6uI9nMhVHjH60oOcDXV/rOcdUTT+713lSjhyEy+aGAjYyfPaLUzvDTYwnriXySFg==}
+  vike-server@1.0.23-commit-79e7a14:
+    resolution: {integrity: sha512-tbEQcFfu8SjKGhEXmWZWRrDOw3I5LEmBmt+fh4vltuiWWZKnFhqotHpDBobMozWS/hNuY6a47Pote8ve19pOrQ==}
     peerDependencies:
-      vike: ^0.4.236
-      vite: ^7.0.6
+      vike: 0.4.237-commit-e549c30
+      vite: ^7.1.3
     peerDependenciesMeta:
       vite:
         optional: true
 
-  vike@0.4.236:
-    resolution: {integrity: sha512-8IRz4OmWGx5YwVBP9Zql405klEgys6tNQh3//IcD4tjhhgIoWm42rtvGb7TVfXX8CNX8DmEPHEvHTsrhk1y7ww==}
+  vike@0.4.237-commit-e549c30:
+    resolution: {integrity: sha512-laPOhYst4MPrxwKpnAV4oBX1zssTtVzAMJ9DH9tuR/nYBGBKTCqWF5j/dO63RwkwhmxJ6aNKaiajI98u74xmGg==}
     engines: {node: '>=18.0.0'}
     hasBin: true
     peerDependencies:
       react-streaming: '>=0.3.42'
-      vite: ^7.0.6
+      vite: ^7.1.3
     peerDependenciesMeta:
       react-streaming:
         optional: true
@@ -2889,10 +2889,10 @@ packages:
   vite-plugin-wasm@3.5.0:
     resolution: {integrity: sha512-X5VWgCnqiQEGb+omhlBVsvTfxikKtoOgAzQ95+BZ8gQ+VfMHIjSHr0wyvXFQCa0eKQ0fKyaL0kWcEnYqBac4lQ==}
     peerDependencies:
-      vite: ^7.0.6
+      vite: ^7.1.3
 
-  vite@7.0.6:
-    resolution: {integrity: sha512-MHFiOENNBd+Bd9uvc8GEsIzdkn1JxMmEeYX35tI3fv0sJBUTfW5tQsoaOwuY4KhBI09A3dUJ/DXf2yxPVPUceg==}
+  vite@7.1.3:
+    resolution: {integrity: sha512-OOUi5zjkDxYrKhTV3V7iKsoS37VUM7v40+HuwEmcrsf11Cdx9y3DIr2Px6liIcZFwt3XSRpQvFpL3WVy7ApkGw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -3200,7 +3200,7 @@ snapshots:
 
   '@brillout/import@0.2.6': {}
 
-  '@brillout/json-serializer@0.5.16': {}
+  '@brillout/json-serializer@0.5.20': {}
 
   '@brillout/libassert@0.5.8': {}
 
@@ -3583,26 +3583,26 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
 
-  '@photonjs/core@0.0.1-commit-877032a(vite@7.0.6(@types/node@20.19.9))':
+  '@photonjs/core@0.0.3(vite@7.1.3(@types/node@20.19.9))':
     dependencies:
       '@brillout/picocolors': 1.0.28
       '@brillout/vite-plugin-server-entry': 0.7.12
-      '@universal-middleware/cloudflare': 0.4.10(hono@4.8.10)
+      '@universal-middleware/cloudflare': 0.4.10(hono@4.9.4)
       '@universal-middleware/compress': 0.2.30
-      '@universal-middleware/core': 0.4.9(hono@4.8.10)
-      '@universal-middleware/elysia': 0.5.3(hono@4.8.10)
-      '@universal-middleware/express': 0.4.19(hono@4.8.10)
-      '@universal-middleware/fastify': 0.5.20(hono@4.8.10)
-      '@universal-middleware/h3': 0.4.12(hono@4.8.10)
-      '@universal-middleware/hattip': 0.4.12(hono@4.8.10)
-      '@universal-middleware/hono': 0.4.16(hono@4.8.10)
+      '@universal-middleware/core': 0.4.9(hono@4.9.4)
+      '@universal-middleware/elysia': 0.5.3(hono@4.9.4)
+      '@universal-middleware/express': 0.4.19(hono@4.9.4)
+      '@universal-middleware/fastify': 0.5.20(hono@4.9.4)
+      '@universal-middleware/h3': 0.4.12(hono@4.9.4)
+      '@universal-middleware/hattip': 0.4.12(hono@4.9.4)
+      '@universal-middleware/hono': 0.4.16(hono@4.9.4)
       '@universal-middleware/sirv': 0.1.20
       estree-walker: 3.0.3
-      hono: 4.8.10
+      hono: 4.9.4
       ts-deepmerge: 7.0.3
       zod: 3.25.76
     optionalDependencies:
-      vite: 7.0.6(@types/node@20.19.9)
+      vite: 7.1.3(@types/node@20.19.9)
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - '@hattip/core'
@@ -3790,9 +3790,9 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@universal-middleware/cloudflare@0.4.10(hono@4.8.10)':
+  '@universal-middleware/cloudflare@0.4.10(hono@4.9.4)':
     dependencies:
-      '@universal-middleware/core': 0.4.9(hono@4.8.10)
+      '@universal-middleware/core': 0.4.9(hono@4.9.4)
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - '@hattip/core'
@@ -3804,16 +3804,16 @@ snapshots:
 
   '@universal-middleware/compress@0.2.30': {}
 
-  '@universal-middleware/core@0.4.9(hono@4.8.10)':
+  '@universal-middleware/core@0.4.9(hono@4.9.4)':
     dependencies:
       regexparam: 3.0.0
       tough-cookie: 5.1.2
     optionalDependencies:
-      hono: 4.8.10
+      hono: 4.9.4
 
-  '@universal-middleware/elysia@0.5.3(hono@4.8.10)':
+  '@universal-middleware/elysia@0.5.3(hono@4.9.4)':
     dependencies:
-      '@universal-middleware/core': 0.4.9(hono@4.8.10)
+      '@universal-middleware/core': 0.4.9(hono@4.9.4)
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - '@hattip/core'
@@ -3823,9 +3823,9 @@ snapshots:
       - h3
       - hono
 
-  '@universal-middleware/express@0.4.19(hono@4.8.10)':
+  '@universal-middleware/express@0.4.19(hono@4.9.4)':
     dependencies:
-      '@universal-middleware/core': 0.4.9(hono@4.8.10)
+      '@universal-middleware/core': 0.4.9(hono@4.9.4)
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - '@hattip/core'
@@ -3835,10 +3835,10 @@ snapshots:
       - h3
       - hono
 
-  '@universal-middleware/fastify@0.5.20(hono@4.8.10)':
+  '@universal-middleware/fastify@0.5.20(hono@4.9.4)':
     dependencies:
-      '@universal-middleware/core': 0.4.9(hono@4.8.10)
-      '@universal-middleware/express': 0.4.19(hono@4.8.10)
+      '@universal-middleware/core': 0.4.9(hono@4.9.4)
+      '@universal-middleware/express': 0.4.19(hono@4.9.4)
       fastify-raw-body: 5.0.0
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
@@ -3849,9 +3849,9 @@ snapshots:
       - h3
       - hono
 
-  '@universal-middleware/h3@0.4.12(hono@4.8.10)':
+  '@universal-middleware/h3@0.4.12(hono@4.9.4)':
     dependencies:
-      '@universal-middleware/core': 0.4.9(hono@4.8.10)
+      '@universal-middleware/core': 0.4.9(hono@4.9.4)
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - '@hattip/core'
@@ -3861,9 +3861,9 @@ snapshots:
       - h3
       - hono
 
-  '@universal-middleware/hattip@0.4.12(hono@4.8.10)':
+  '@universal-middleware/hattip@0.4.12(hono@4.9.4)':
     dependencies:
-      '@universal-middleware/core': 0.4.9(hono@4.8.10)
+      '@universal-middleware/core': 0.4.9(hono@4.9.4)
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - '@hattip/core'
@@ -3873,9 +3873,9 @@ snapshots:
       - h3
       - hono
 
-  '@universal-middleware/hono@0.4.16(hono@4.8.10)':
+  '@universal-middleware/hono@0.4.16(hono@4.9.4)':
     dependencies:
-      '@universal-middleware/core': 0.4.9(hono@4.8.10)
+      '@universal-middleware/core': 0.4.9(hono@4.9.4)
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - '@hattip/core'
@@ -3890,13 +3890,13 @@ snapshots:
       mrmime: 2.0.1
       totalist: 3.0.1
 
-  '@universal-middleware/vercel@0.4.20(@universal-middleware/h3@0.4.12(hono@4.8.10))(hono@4.8.10)':
+  '@universal-middleware/vercel@0.4.20(@universal-middleware/h3@0.4.12(hono@4.9.4))(hono@4.9.4)':
     dependencies:
-      '@universal-middleware/core': 0.4.9(hono@4.8.10)
-      '@universal-middleware/express': 0.4.19(hono@4.8.10)
+      '@universal-middleware/core': 0.4.9(hono@4.9.4)
+      '@universal-middleware/express': 0.4.19(hono@4.9.4)
     optionalDependencies:
-      '@universal-middleware/h3': 0.4.12(hono@4.8.10)
-      hono: 4.8.10
+      '@universal-middleware/h3': 0.4.12(hono@4.9.4)
+      hono: 4.9.4
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - '@webroute/route'
@@ -3998,7 +3998,7 @@ snapshots:
       json-schema-to-ts: 1.6.4
       ts-morph: 12.0.0
 
-  '@vitejs/plugin-react@4.7.0(vite@7.0.6(@types/node@20.19.9))':
+  '@vitejs/plugin-react@4.7.0(vite@7.1.3(@types/node@20.19.9))':
     dependencies:
       '@babel/core': 7.28.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.0)
@@ -4006,7 +4006,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 7.0.6(@types/node@20.19.9)
+      vite: 7.1.3(@types/node@20.19.9)
     transitivePeerDependencies:
       - supports-color
 
@@ -4018,13 +4018,13 @@ snapshots:
       chai: 5.2.1
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@7.0.6(@types/node@20.19.9))':
+  '@vitest/mocker@3.2.4(vite@7.1.3(@types/node@20.19.9))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 7.0.6(@types/node@20.19.9)
+      vite: 7.1.3(@types/node@20.19.9)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -4567,7 +4567,7 @@ snapshots:
     dependencies:
       reusify: 1.1.0
 
-  fdir@6.4.6(picomatch@4.0.3):
+  fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
       picomatch: 4.0.3
 
@@ -4735,7 +4735,7 @@ snapshots:
 
   hex-rgb@4.3.0: {}
 
-  hono@4.8.10: {}
+  hono@4.9.4: {}
 
   http-errors@2.0.0:
     dependencies:
@@ -5407,7 +5407,7 @@ snapshots:
   react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1):
     dependencies:
       '@brillout/import': 0.2.6
-      '@brillout/json-serializer': 0.5.16
+      '@brillout/json-serializer': 0.5.20
       '@brillout/picocolors': 1.0.28
       isbot-fast: 1.2.0
       react: 19.1.1
@@ -5681,7 +5681,7 @@ snapshots:
 
   tinyglobby@0.2.14:
     dependencies:
-      fdir: 6.4.6(picomatch@4.0.3)
+      fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
 
   tinypool@1.1.1: {}
@@ -5861,32 +5861,32 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vike-react@0.6.5(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(vike@0.4.236(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.0.6(@types/node@20.19.9))):
+  vike-react@0.6.5(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(vike@0.4.237-commit-e549c30(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.3(@types/node@20.19.9))):
     dependencies:
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
       react-streaming: 0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      vike: 0.4.236(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.0.6(@types/node@20.19.9))
+      vike: 0.4.237-commit-e549c30(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.3(@types/node@20.19.9))
 
-  vike-server@1.0.16-commit-91ea469(hono@4.8.10)(vike@0.4.236(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.0.6(@types/node@20.19.9)))(vite@7.0.6(@types/node@20.19.9)):
+  vike-server@1.0.23-commit-79e7a14(hono@4.9.4)(vike@0.4.237-commit-e549c30(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.3(@types/node@20.19.9)))(vite@7.1.3(@types/node@20.19.9)):
     dependencies:
       '@brillout/picocolors': 1.0.28
       '@brillout/vite-plugin-server-entry': 0.7.12
-      '@photonjs/core': 0.0.1-commit-877032a(vite@7.0.6(@types/node@20.19.9))
+      '@photonjs/core': 0.0.3(vite@7.1.3(@types/node@20.19.9))
       '@universal-middleware/compress': 0.2.30
-      '@universal-middleware/core': 0.4.9(hono@4.8.10)
-      '@universal-middleware/elysia': 0.5.3(hono@4.8.10)
-      '@universal-middleware/express': 0.4.19(hono@4.8.10)
-      '@universal-middleware/fastify': 0.5.20(hono@4.8.10)
-      '@universal-middleware/h3': 0.4.12(hono@4.8.10)
-      '@universal-middleware/hattip': 0.4.12(hono@4.8.10)
-      '@universal-middleware/hono': 0.4.16(hono@4.8.10)
+      '@universal-middleware/core': 0.4.9(hono@4.9.4)
+      '@universal-middleware/elysia': 0.5.3(hono@4.9.4)
+      '@universal-middleware/express': 0.4.19(hono@4.9.4)
+      '@universal-middleware/fastify': 0.5.20(hono@4.9.4)
+      '@universal-middleware/h3': 0.4.12(hono@4.9.4)
+      '@universal-middleware/hattip': 0.4.12(hono@4.9.4)
+      '@universal-middleware/hono': 0.4.16(hono@4.9.4)
       '@universal-middleware/sirv': 0.1.20
       arktype: 2.1.20
       esbuild: 0.25.8
-      vike: 0.4.236(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.0.6(@types/node@20.19.9))
+      vike: 0.4.237-commit-e549c30(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.3(@types/node@20.19.9))
     optionalDependencies:
-      vite: 7.0.6(@types/node@20.19.9)
+      vite: 7.1.3(@types/node@20.19.9)
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - '@hattip/core'
@@ -5896,10 +5896,10 @@ snapshots:
       - h3
       - hono
 
-  vike@0.4.236(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.0.6(@types/node@20.19.9)):
+  vike@0.4.237-commit-e549c30(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.3(@types/node@20.19.9)):
     dependencies:
       '@brillout/import': 0.2.6
-      '@brillout/json-serializer': 0.5.16
+      '@brillout/json-serializer': 0.5.20
       '@brillout/picocolors': 1.0.28
       '@brillout/require-shim': 0.1.2
       '@brillout/vite-plugin-server-entry': 0.7.12
@@ -5916,7 +5916,7 @@ snapshots:
       tinyglobby: 0.2.14
     optionalDependencies:
       react-streaming: 0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      vite: 7.0.6(@types/node@20.19.9)
+      vite: 7.1.3(@types/node@20.19.9)
 
   vite-node@3.2.4(@types/node@20.19.9):
     dependencies:
@@ -5924,7 +5924,7 @@ snapshots:
       debug: 4.4.1
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.0.6(@types/node@20.19.9)
+      vite: 7.1.3(@types/node@20.19.9)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -5939,14 +5939,14 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plugin-wasm@3.5.0(vite@7.0.6(@types/node@20.19.9)):
+  vite-plugin-wasm@3.5.0(vite@7.1.3(@types/node@20.19.9)):
     dependencies:
-      vite: 7.0.6(@types/node@20.19.9)
+      vite: 7.1.3(@types/node@20.19.9)
 
-  vite@7.0.6(@types/node@20.19.9):
+  vite@7.1.3(@types/node@20.19.9):
     dependencies:
       esbuild: 0.25.8
-      fdir: 6.4.6(picomatch@4.0.3)
+      fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
       postcss: 8.5.6
       rollup: 4.46.2
@@ -5959,7 +5959,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.0.6(@types/node@20.19.9))
+      '@vitest/mocker': 3.2.4(vite@7.1.3(@types/node@20.19.9))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -5977,7 +5977,7 @@ snapshots:
       tinyglobby: 0.2.14
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.0.6(@types/node@20.19.9)
+      vite: 7.1.3(@types/node@20.19.9)
       vite-node: 3.2.4(@types/node@20.19.9)
       why-is-node-running: 2.3.0
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 overrides:
   path-to-regexp@>=4.0.0 <6.3.0: ^6.3.0
-  vike: 0.4.237-commit-fd8294f
+  vike: 0.4.237-commit-2d6f480
   vite: ^7.1.3
 
 importers:
@@ -68,11 +68,11 @@ importers:
         specifier: ^5.8.3
         version: 5.8.3
       vike:
-        specifier: 0.4.237-commit-fd8294f
-        version: 0.4.237-commit-fd8294f(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.3(@types/node@20.19.9))
+        specifier: 0.4.237-commit-2d6f480
+        version: 0.4.237-commit-2d6f480(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.3(@types/node@20.19.9))
       vike-react:
         specifier: ^0.6.5
-        version: 0.6.5(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(vike@0.4.237-commit-fd8294f(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.3(@types/node@20.19.9)))
+        version: 0.6.5(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(vike@0.4.237-commit-2d6f480(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.3(@types/node@20.19.9)))
       vike-vercel:
         specifier: workspace:^
         version: link:../../packages/vike
@@ -118,7 +118,7 @@ importers:
         version: 1.54.1
       vike-server:
         specifier: 1.0.23-commit-52c7d04
-        version: 1.0.23-commit-52c7d04(hono@4.9.4)(vike@0.4.237-commit-fd8294f(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.3(@types/node@20.19.9)))(vite@7.1.3(@types/node@20.19.9))
+        version: 1.0.23-commit-52c7d04(hono@4.9.4)(vike@0.4.237-commit-2d6f480(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.3(@types/node@20.19.9)))(vite@7.1.3(@types/node@20.19.9))
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@20.19.9)
@@ -271,11 +271,11 @@ importers:
         specifier: ^0.0.3
         version: 0.0.3(vite@7.1.3(@types/node@20.19.9))
       vike:
-        specifier: 0.4.237-commit-fd8294f
-        version: 0.4.237-commit-fd8294f(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.3(@types/node@20.19.9))
+        specifier: 0.4.237-commit-2d6f480
+        version: 0.4.237-commit-2d6f480(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.3(@types/node@20.19.9))
       vike-server:
         specifier: 1.0.23-commit-52c7d04
-        version: 1.0.23-commit-52c7d04(hono@4.9.4)(vike@0.4.237-commit-fd8294f(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.3(@types/node@20.19.9)))(vite@7.1.3(@types/node@20.19.9))
+        version: 1.0.23-commit-52c7d04(hono@4.9.4)(vike@0.4.237-commit-2d6f480(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.3(@types/node@20.19.9)))(vite@7.1.3(@types/node@20.19.9))
     devDependencies:
       '@types/node':
         specifier: ^20.19.9
@@ -2857,19 +2857,19 @@ packages:
     peerDependencies:
       react: '>=19'
       react-dom: '>=19'
-      vike: 0.4.237-commit-fd8294f
+      vike: 0.4.237-commit-2d6f480
 
   vike-server@1.0.23-commit-52c7d04:
     resolution: {integrity: sha512-q+2FEhWtp9gt5VoH4dA/oCs87hYKGUIFWhuajfwURfgJcZVfT7Vx9+s0+rk35CMzIt5oToIXf5ZOk+wbhLSKlA==}
     peerDependencies:
-      vike: 0.4.237-commit-fd8294f
+      vike: 0.4.237-commit-2d6f480
       vite: ^7.1.3
     peerDependenciesMeta:
       vite:
         optional: true
 
-  vike@0.4.237-commit-fd8294f:
-    resolution: {integrity: sha512-DRPGQSsrb4Ge2Tq2gSfB0KWa6u94m+Ra8I7HxHR+LIG8JOrxPmaUcWLDB/0+KCZVHm+TVVFMdr1JvuKOufy5Mg==}
+  vike@0.4.237-commit-2d6f480:
+    resolution: {integrity: sha512-OLsgfn2cD9A1WV2fs16/MUH0QvQG7QtSaUoBbZInVjkZ9G05HJ82WIs7CrYsnhrvVMtKkQLVa3k3G4nJkR4oow==}
     engines: {node: '>=18.0.0'}
     hasBin: true
     peerDependencies:
@@ -5861,14 +5861,14 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vike-react@0.6.5(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(vike@0.4.237-commit-fd8294f(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.3(@types/node@20.19.9))):
+  vike-react@0.6.5(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(vike@0.4.237-commit-2d6f480(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.3(@types/node@20.19.9))):
     dependencies:
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
       react-streaming: 0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      vike: 0.4.237-commit-fd8294f(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.3(@types/node@20.19.9))
+      vike: 0.4.237-commit-2d6f480(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.3(@types/node@20.19.9))
 
-  vike-server@1.0.23-commit-52c7d04(hono@4.9.4)(vike@0.4.237-commit-fd8294f(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.3(@types/node@20.19.9)))(vite@7.1.3(@types/node@20.19.9)):
+  vike-server@1.0.23-commit-52c7d04(hono@4.9.4)(vike@0.4.237-commit-2d6f480(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.3(@types/node@20.19.9)))(vite@7.1.3(@types/node@20.19.9)):
     dependencies:
       '@brillout/picocolors': 1.0.28
       '@brillout/vite-plugin-server-entry': 0.7.13
@@ -5884,7 +5884,7 @@ snapshots:
       '@universal-middleware/sirv': 0.1.20
       arktype: 2.1.20
       esbuild: 0.25.8
-      vike: 0.4.237-commit-fd8294f(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.3(@types/node@20.19.9))
+      vike: 0.4.237-commit-2d6f480(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.3(@types/node@20.19.9))
     optionalDependencies:
       vite: 7.1.3(@types/node@20.19.9)
     transitivePeerDependencies:
@@ -5896,7 +5896,7 @@ snapshots:
       - h3
       - hono
 
-  vike@0.4.237-commit-fd8294f(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.3(@types/node@20.19.9)):
+  vike@0.4.237-commit-2d6f480(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.3(@types/node@20.19.9)):
     dependencies:
       '@brillout/import': 0.2.6
       '@brillout/json-serializer': 0.5.20

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 overrides:
   path-to-regexp@>=4.0.0 <6.3.0: ^6.3.0
-  vike: 0.4.237-commit-e549c30
+  vike: 0.4.237-commit-fd8294f
   vite: ^7.1.3
 
 importers:
@@ -68,11 +68,11 @@ importers:
         specifier: ^5.8.3
         version: 5.8.3
       vike:
-        specifier: 0.4.237-commit-e549c30
-        version: 0.4.237-commit-e549c30(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.3(@types/node@20.19.9))
+        specifier: 0.4.237-commit-fd8294f
+        version: 0.4.237-commit-fd8294f(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.3(@types/node@20.19.9))
       vike-react:
         specifier: ^0.6.5
-        version: 0.6.5(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(vike@0.4.237-commit-e549c30(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.3(@types/node@20.19.9)))
+        version: 0.6.5(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(vike@0.4.237-commit-fd8294f(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.3(@types/node@20.19.9)))
       vike-vercel:
         specifier: workspace:^
         version: link:../../packages/vike
@@ -117,8 +117,8 @@ importers:
         specifier: ^1.54.1
         version: 1.54.1
       vike-server:
-        specifier: 1.0.23-commit-79e7a14
-        version: 1.0.23-commit-79e7a14(hono@4.9.4)(vike@0.4.237-commit-e549c30(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.3(@types/node@20.19.9)))(vite@7.1.3(@types/node@20.19.9))
+        specifier: 1.0.23-commit-52c7d04
+        version: 1.0.23-commit-52c7d04(hono@4.9.4)(vike@0.4.237-commit-fd8294f(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.3(@types/node@20.19.9)))(vite@7.1.3(@types/node@20.19.9))
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@20.19.9)
@@ -271,11 +271,11 @@ importers:
         specifier: ^0.0.3
         version: 0.0.3(vite@7.1.3(@types/node@20.19.9))
       vike:
-        specifier: 0.4.237-commit-e549c30
-        version: 0.4.237-commit-e549c30(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.3(@types/node@20.19.9))
+        specifier: 0.4.237-commit-fd8294f
+        version: 0.4.237-commit-fd8294f(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.3(@types/node@20.19.9))
       vike-server:
-        specifier: 1.0.23-commit-79e7a14
-        version: 1.0.23-commit-79e7a14(hono@4.9.4)(vike@0.4.237-commit-e549c30(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.3(@types/node@20.19.9)))(vite@7.1.3(@types/node@20.19.9))
+        specifier: 1.0.23-commit-52c7d04
+        version: 1.0.23-commit-52c7d04(hono@4.9.4)(vike@0.4.237-commit-fd8294f(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.3(@types/node@20.19.9)))(vite@7.1.3(@types/node@20.19.9))
     devDependencies:
       '@types/node':
         specifier: ^20.19.9
@@ -479,8 +479,8 @@ packages:
   '@brillout/require-shim@0.1.2':
     resolution: {integrity: sha512-3I4LRHnVZXoSAsEoni5mosq9l6eiJED58d9V954W4CIZ88AUfYBanWGBGbJG3NztaRTpFHEA6wB3Hn93BmmJdg==}
 
-  '@brillout/vite-plugin-server-entry@0.7.12':
-    resolution: {integrity: sha512-yh+tsIl2qpStgj1JofxC6tb1WoDYHGnth7XZtHou5baRkBE7DgmoCRIE+kw6S3511KwCMOcuBQSUszrYg5dLUw==}
+  '@brillout/vite-plugin-server-entry@0.7.13':
+    resolution: {integrity: sha512-fyUCB205PZwnMoGJtm73BhAs6G++AtmCJNdrud8/p6BHjTMIfP1upY2Em9WsNrzV9q61ZbUx1LGyYkECyLEwFQ==}
 
   '@changesets/apply-release-plan@7.0.12':
     resolution: {integrity: sha512-EaET7As5CeuhTzvXTQCRZeBUcisoYPDDcXvgTE/2jmmypKp0RC7LxKj/yzqeh/1qFTZI7oDGFcL1PHRuQuketQ==}
@@ -2857,19 +2857,19 @@ packages:
     peerDependencies:
       react: '>=19'
       react-dom: '>=19'
-      vike: 0.4.237-commit-e549c30
+      vike: 0.4.237-commit-fd8294f
 
-  vike-server@1.0.23-commit-79e7a14:
-    resolution: {integrity: sha512-tbEQcFfu8SjKGhEXmWZWRrDOw3I5LEmBmt+fh4vltuiWWZKnFhqotHpDBobMozWS/hNuY6a47Pote8ve19pOrQ==}
+  vike-server@1.0.23-commit-52c7d04:
+    resolution: {integrity: sha512-q+2FEhWtp9gt5VoH4dA/oCs87hYKGUIFWhuajfwURfgJcZVfT7Vx9+s0+rk35CMzIt5oToIXf5ZOk+wbhLSKlA==}
     peerDependencies:
-      vike: 0.4.237-commit-e549c30
+      vike: 0.4.237-commit-fd8294f
       vite: ^7.1.3
     peerDependenciesMeta:
       vite:
         optional: true
 
-  vike@0.4.237-commit-e549c30:
-    resolution: {integrity: sha512-laPOhYst4MPrxwKpnAV4oBX1zssTtVzAMJ9DH9tuR/nYBGBKTCqWF5j/dO63RwkwhmxJ6aNKaiajI98u74xmGg==}
+  vike@0.4.237-commit-fd8294f:
+    resolution: {integrity: sha512-DRPGQSsrb4Ge2Tq2gSfB0KWa6u94m+Ra8I7HxHR+LIG8JOrxPmaUcWLDB/0+KCZVHm+TVVFMdr1JvuKOufy5Mg==}
     engines: {node: '>=18.0.0'}
     hasBin: true
     peerDependencies:
@@ -3208,7 +3208,7 @@ snapshots:
 
   '@brillout/require-shim@0.1.2': {}
 
-  '@brillout/vite-plugin-server-entry@0.7.12':
+  '@brillout/vite-plugin-server-entry@0.7.13':
     dependencies:
       '@brillout/import': 0.2.6
       '@brillout/picocolors': 1.0.28
@@ -3586,7 +3586,7 @@ snapshots:
   '@photonjs/core@0.0.3(vite@7.1.3(@types/node@20.19.9))':
     dependencies:
       '@brillout/picocolors': 1.0.28
-      '@brillout/vite-plugin-server-entry': 0.7.12
+      '@brillout/vite-plugin-server-entry': 0.7.13
       '@universal-middleware/cloudflare': 0.4.10(hono@4.9.4)
       '@universal-middleware/compress': 0.2.30
       '@universal-middleware/core': 0.4.9(hono@4.9.4)
@@ -5861,17 +5861,17 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vike-react@0.6.5(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(vike@0.4.237-commit-e549c30(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.3(@types/node@20.19.9))):
+  vike-react@0.6.5(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(vike@0.4.237-commit-fd8294f(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.3(@types/node@20.19.9))):
     dependencies:
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
       react-streaming: 0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      vike: 0.4.237-commit-e549c30(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.3(@types/node@20.19.9))
+      vike: 0.4.237-commit-fd8294f(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.3(@types/node@20.19.9))
 
-  vike-server@1.0.23-commit-79e7a14(hono@4.9.4)(vike@0.4.237-commit-e549c30(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.3(@types/node@20.19.9)))(vite@7.1.3(@types/node@20.19.9)):
+  vike-server@1.0.23-commit-52c7d04(hono@4.9.4)(vike@0.4.237-commit-fd8294f(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.3(@types/node@20.19.9)))(vite@7.1.3(@types/node@20.19.9)):
     dependencies:
       '@brillout/picocolors': 1.0.28
-      '@brillout/vite-plugin-server-entry': 0.7.12
+      '@brillout/vite-plugin-server-entry': 0.7.13
       '@photonjs/core': 0.0.3(vite@7.1.3(@types/node@20.19.9))
       '@universal-middleware/compress': 0.2.30
       '@universal-middleware/core': 0.4.9(hono@4.9.4)
@@ -5884,7 +5884,7 @@ snapshots:
       '@universal-middleware/sirv': 0.1.20
       arktype: 2.1.20
       esbuild: 0.25.8
-      vike: 0.4.237-commit-e549c30(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.3(@types/node@20.19.9))
+      vike: 0.4.237-commit-fd8294f(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.3(@types/node@20.19.9))
     optionalDependencies:
       vite: 7.1.3(@types/node@20.19.9)
     transitivePeerDependencies:
@@ -5896,13 +5896,13 @@ snapshots:
       - h3
       - hono
 
-  vike@0.4.237-commit-e549c30(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.3(@types/node@20.19.9)):
+  vike@0.4.237-commit-fd8294f(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.3(@types/node@20.19.9)):
     dependencies:
       '@brillout/import': 0.2.6
       '@brillout/json-serializer': 0.5.20
       '@brillout/picocolors': 1.0.28
       '@brillout/require-shim': 0.1.2
-      '@brillout/vite-plugin-server-entry': 0.7.12
+      '@brillout/vite-plugin-server-entry': 0.7.13
       acorn: 8.15.0
       cac: 6.7.14
       es-module-lexer: 1.7.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 overrides:
   path-to-regexp@>=4.0.0 <6.3.0: ^6.3.0
-  vike: 0.4.237-commit-2d6f480
+  vike: 0.4.237-commit-2c1db32
   vite: ^7.1.3
 
 importers:
@@ -68,11 +68,11 @@ importers:
         specifier: ^5.8.3
         version: 5.8.3
       vike:
-        specifier: 0.4.237-commit-2d6f480
-        version: 0.4.237-commit-2d6f480(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.3(@types/node@20.19.9))
+        specifier: 0.4.237-commit-2c1db32
+        version: 0.4.237-commit-2c1db32(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.3(@types/node@20.19.9))
       vike-react:
         specifier: ^0.6.5
-        version: 0.6.5(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(vike@0.4.237-commit-2d6f480(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.3(@types/node@20.19.9)))
+        version: 0.6.5(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(vike@0.4.237-commit-2c1db32(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.3(@types/node@20.19.9)))
       vike-vercel:
         specifier: workspace:^
         version: link:../../packages/vike
@@ -118,7 +118,7 @@ importers:
         version: 1.54.1
       vike-server:
         specifier: 1.0.23-commit-52c7d04
-        version: 1.0.23-commit-52c7d04(hono@4.9.4)(vike@0.4.237-commit-2d6f480(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.3(@types/node@20.19.9)))(vite@7.1.3(@types/node@20.19.9))
+        version: 1.0.23-commit-52c7d04(hono@4.9.4)(vike@0.4.237-commit-2c1db32(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.3(@types/node@20.19.9)))(vite@7.1.3(@types/node@20.19.9))
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@20.19.9)
@@ -271,11 +271,11 @@ importers:
         specifier: ^0.0.3
         version: 0.0.3(vite@7.1.3(@types/node@20.19.9))
       vike:
-        specifier: 0.4.237-commit-2d6f480
-        version: 0.4.237-commit-2d6f480(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.3(@types/node@20.19.9))
+        specifier: 0.4.237-commit-2c1db32
+        version: 0.4.237-commit-2c1db32(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.3(@types/node@20.19.9))
       vike-server:
         specifier: 1.0.23-commit-52c7d04
-        version: 1.0.23-commit-52c7d04(hono@4.9.4)(vike@0.4.237-commit-2d6f480(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.3(@types/node@20.19.9)))(vite@7.1.3(@types/node@20.19.9))
+        version: 1.0.23-commit-52c7d04(hono@4.9.4)(vike@0.4.237-commit-2c1db32(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.3(@types/node@20.19.9)))(vite@7.1.3(@types/node@20.19.9))
     devDependencies:
       '@types/node':
         specifier: ^20.19.9
@@ -2857,19 +2857,19 @@ packages:
     peerDependencies:
       react: '>=19'
       react-dom: '>=19'
-      vike: 0.4.237-commit-2d6f480
+      vike: 0.4.237-commit-2c1db32
 
   vike-server@1.0.23-commit-52c7d04:
     resolution: {integrity: sha512-q+2FEhWtp9gt5VoH4dA/oCs87hYKGUIFWhuajfwURfgJcZVfT7Vx9+s0+rk35CMzIt5oToIXf5ZOk+wbhLSKlA==}
     peerDependencies:
-      vike: 0.4.237-commit-2d6f480
+      vike: 0.4.237-commit-2c1db32
       vite: ^7.1.3
     peerDependenciesMeta:
       vite:
         optional: true
 
-  vike@0.4.237-commit-2d6f480:
-    resolution: {integrity: sha512-OLsgfn2cD9A1WV2fs16/MUH0QvQG7QtSaUoBbZInVjkZ9G05HJ82WIs7CrYsnhrvVMtKkQLVa3k3G4nJkR4oow==}
+  vike@0.4.237-commit-2c1db32:
+    resolution: {integrity: sha512-OsqxtZ8NcCZ7/A0ANsBQM7Au7obcgPpCcIxn/KLneAV3t3feEmZSXmatXb1s/oZE3C1XZmO0BSomhNnU8aobhA==}
     engines: {node: '>=18.0.0'}
     hasBin: true
     peerDependencies:
@@ -5861,14 +5861,14 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vike-react@0.6.5(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(vike@0.4.237-commit-2d6f480(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.3(@types/node@20.19.9))):
+  vike-react@0.6.5(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(vike@0.4.237-commit-2c1db32(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.3(@types/node@20.19.9))):
     dependencies:
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
       react-streaming: 0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      vike: 0.4.237-commit-2d6f480(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.3(@types/node@20.19.9))
+      vike: 0.4.237-commit-2c1db32(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.3(@types/node@20.19.9))
 
-  vike-server@1.0.23-commit-52c7d04(hono@4.9.4)(vike@0.4.237-commit-2d6f480(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.3(@types/node@20.19.9)))(vite@7.1.3(@types/node@20.19.9)):
+  vike-server@1.0.23-commit-52c7d04(hono@4.9.4)(vike@0.4.237-commit-2c1db32(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.3(@types/node@20.19.9)))(vite@7.1.3(@types/node@20.19.9)):
     dependencies:
       '@brillout/picocolors': 1.0.28
       '@brillout/vite-plugin-server-entry': 0.7.13
@@ -5884,7 +5884,7 @@ snapshots:
       '@universal-middleware/sirv': 0.1.20
       arktype: 2.1.20
       esbuild: 0.25.8
-      vike: 0.4.237-commit-2d6f480(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.3(@types/node@20.19.9))
+      vike: 0.4.237-commit-2c1db32(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.3(@types/node@20.19.9))
     optionalDependencies:
       vite: 7.1.3(@types/node@20.19.9)
     transitivePeerDependencies:
@@ -5896,7 +5896,7 @@ snapshots:
       - h3
       - hono
 
-  vike@0.4.237-commit-2d6f480(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.3(@types/node@20.19.9)):
+  vike@0.4.237-commit-2c1db32(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.3(@types/node@20.19.9)):
     dependencies:
       '@brillout/import': 0.2.6
       '@brillout/json-serializer': 0.5.20

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 overrides:
   path-to-regexp@>=4.0.0 <6.3.0: ^6.3.0
-  vike: 0.4.237-commit-2c1db32
+  vike: 0.4.237-commit-cc7f0f6
   vite: ^7.1.3
 
 importers:
@@ -68,11 +68,11 @@ importers:
         specifier: ^5.8.3
         version: 5.8.3
       vike:
-        specifier: 0.4.237-commit-2c1db32
-        version: 0.4.237-commit-2c1db32(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.3(@types/node@20.19.9))
+        specifier: 0.4.237-commit-cc7f0f6
+        version: 0.4.237-commit-cc7f0f6(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.3(@types/node@20.19.9))
       vike-react:
         specifier: ^0.6.5
-        version: 0.6.5(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(vike@0.4.237-commit-2c1db32(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.3(@types/node@20.19.9)))
+        version: 0.6.5(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(vike@0.4.237-commit-cc7f0f6(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.3(@types/node@20.19.9)))
       vike-vercel:
         specifier: workspace:^
         version: link:../../packages/vike
@@ -118,7 +118,7 @@ importers:
         version: 1.54.1
       vike-server:
         specifier: 1.0.23-commit-52c7d04
-        version: 1.0.23-commit-52c7d04(hono@4.9.4)(vike@0.4.237-commit-2c1db32(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.3(@types/node@20.19.9)))(vite@7.1.3(@types/node@20.19.9))
+        version: 1.0.23-commit-52c7d04(hono@4.9.4)(vike@0.4.237-commit-cc7f0f6(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.3(@types/node@20.19.9)))(vite@7.1.3(@types/node@20.19.9))
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@20.19.9)
@@ -271,11 +271,11 @@ importers:
         specifier: ^0.0.3
         version: 0.0.3(vite@7.1.3(@types/node@20.19.9))
       vike:
-        specifier: 0.4.237-commit-2c1db32
-        version: 0.4.237-commit-2c1db32(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.3(@types/node@20.19.9))
+        specifier: 0.4.237-commit-cc7f0f6
+        version: 0.4.237-commit-cc7f0f6(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.3(@types/node@20.19.9))
       vike-server:
         specifier: 1.0.23-commit-52c7d04
-        version: 1.0.23-commit-52c7d04(hono@4.9.4)(vike@0.4.237-commit-2c1db32(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.3(@types/node@20.19.9)))(vite@7.1.3(@types/node@20.19.9))
+        version: 1.0.23-commit-52c7d04(hono@4.9.4)(vike@0.4.237-commit-cc7f0f6(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.3(@types/node@20.19.9)))(vite@7.1.3(@types/node@20.19.9))
     devDependencies:
       '@types/node':
         specifier: ^20.19.9
@@ -2857,19 +2857,19 @@ packages:
     peerDependencies:
       react: '>=19'
       react-dom: '>=19'
-      vike: 0.4.237-commit-2c1db32
+      vike: 0.4.237-commit-cc7f0f6
 
   vike-server@1.0.23-commit-52c7d04:
     resolution: {integrity: sha512-q+2FEhWtp9gt5VoH4dA/oCs87hYKGUIFWhuajfwURfgJcZVfT7Vx9+s0+rk35CMzIt5oToIXf5ZOk+wbhLSKlA==}
     peerDependencies:
-      vike: 0.4.237-commit-2c1db32
+      vike: 0.4.237-commit-cc7f0f6
       vite: ^7.1.3
     peerDependenciesMeta:
       vite:
         optional: true
 
-  vike@0.4.237-commit-2c1db32:
-    resolution: {integrity: sha512-OsqxtZ8NcCZ7/A0ANsBQM7Au7obcgPpCcIxn/KLneAV3t3feEmZSXmatXb1s/oZE3C1XZmO0BSomhNnU8aobhA==}
+  vike@0.4.237-commit-cc7f0f6:
+    resolution: {integrity: sha512-C08iuTydyVjobE6n9agw5WPWLOvHBXeoybzpdSLM+huOSddZhBEMPqUOF6pZIqt8GuchU8nKgkNLQd/DuFU74g==}
     engines: {node: '>=18.0.0'}
     hasBin: true
     peerDependencies:
@@ -5861,14 +5861,14 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vike-react@0.6.5(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(vike@0.4.237-commit-2c1db32(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.3(@types/node@20.19.9))):
+  vike-react@0.6.5(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(vike@0.4.237-commit-cc7f0f6(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.3(@types/node@20.19.9))):
     dependencies:
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
       react-streaming: 0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      vike: 0.4.237-commit-2c1db32(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.3(@types/node@20.19.9))
+      vike: 0.4.237-commit-cc7f0f6(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.3(@types/node@20.19.9))
 
-  vike-server@1.0.23-commit-52c7d04(hono@4.9.4)(vike@0.4.237-commit-2c1db32(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.3(@types/node@20.19.9)))(vite@7.1.3(@types/node@20.19.9)):
+  vike-server@1.0.23-commit-52c7d04(hono@4.9.4)(vike@0.4.237-commit-cc7f0f6(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.3(@types/node@20.19.9)))(vite@7.1.3(@types/node@20.19.9)):
     dependencies:
       '@brillout/picocolors': 1.0.28
       '@brillout/vite-plugin-server-entry': 0.7.13
@@ -5884,7 +5884,7 @@ snapshots:
       '@universal-middleware/sirv': 0.1.20
       arktype: 2.1.20
       esbuild: 0.25.8
-      vike: 0.4.237-commit-2c1db32(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.3(@types/node@20.19.9))
+      vike: 0.4.237-commit-cc7f0f6(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.3(@types/node@20.19.9))
     optionalDependencies:
       vite: 7.1.3(@types/node@20.19.9)
     transitivePeerDependencies:
@@ -5896,7 +5896,7 @@ snapshots:
       - h3
       - hono
 
-  vike@0.4.237-commit-2c1db32(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.3(@types/node@20.19.9)):
+  vike@0.4.237-commit-cc7f0f6(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.3(@types/node@20.19.9)):
     dependencies:
       '@brillout/import': 0.2.6
       '@brillout/json-serializer': 0.5.20


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Upgraded dependencies across examples and packages (Vite, vike-server, @photonjs/core); adjusted package overrides and added a Node engines constraint.
- Tests
  - Updated expected static asset path to reflect the new manifest location.
- Style
  - Minor internal import ordering and build-mapping adjustments; no user-facing behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->