### PR TITLE
fix: preserve original request query

### DIFF
--- a/.changeset/brave-ants-smile.md
+++ b/.changeset/brave-ants-smile.md
@@ -1,0 +1,5 @@
+---
+"vite-plugin-vercel": patch
+---
+
+Preserve the original request query string when reconstructing requests from `x-original-path`.

--- a/packages/vite-plugin-vercel/src/utils/request.test.ts
+++ b/packages/vite-plugin-vercel/src/utils/request.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { getOriginalRequest } from "./request";
+
+describe("getOriginalRequest", () => {
+  it("preserves the original request query when x-original-path only contains a pathname", () => {
+    const request = new Request(
+      "https://example.com/webhooks/whatsapp?hub.mode=subscribe&hub.verify_token=token&hub.challenge=local",
+      {
+        headers: {
+          "x-original-path": "/webhooks/whatsapp",
+        },
+      },
+    );
+
+    expect(getOriginalRequest(request).url).toBe(
+      "https://example.com/webhooks/whatsapp?hub.mode=subscribe&hub.verify_token=token&hub.challenge=local",
+    );
+  });
+
+  it("keeps an explicit query from x-original-path", () => {
+    const request = new Request("https://example.com/rewritten?request=value", {
+      headers: {
+        "x-original-path": "/original?original=value",
+      },
+    });
+
+    expect(getOriginalRequest(request).url).toBe("https://example.com/original?original=value");
+  });
+});

--- a/packages/vite-plugin-vercel/src/utils/request.ts
+++ b/packages/vite-plugin-vercel/src/utils/request.ts
@@ -13,10 +13,6 @@ export function getOriginalRequest(request: Request) {
       originalUrl.search = requestUrl.search;
     }
 
-    if (!originalUrl.hash) {
-      originalUrl.hash = requestUrl.hash;
-    }
-
     newUrl = originalUrl.toString();
   }
 

--- a/packages/vite-plugin-vercel/src/utils/request.ts
+++ b/packages/vite-plugin-vercel/src/utils/request.ts
@@ -6,7 +6,18 @@ export function getOriginalRequest(request: Request) {
   let newRequest = request;
 
   if (typeof xOriginalPath === "string") {
-    newUrl = new URL(xOriginalPath, request.url).toString();
+    const requestUrl = new URL(request.url);
+    const originalUrl = new URL(xOriginalPath, requestUrl);
+
+    if (!originalUrl.search) {
+      originalUrl.search = requestUrl.search;
+    }
+
+    if (!originalUrl.hash) {
+      originalUrl.hash = requestUrl.hash;
+    }
+
+    newUrl = originalUrl.toString();
   }
 
   if (newUrl && request.url !== newUrl) {


### PR DESCRIPTION
## Summary

Preserves the original request query string when `getOriginalRequest()` reconstructs a request URL from `x-original-path`.

Currently, when `x-original-path` only contains a pathname, `new URL(xOriginalPath, request.url)` drops the original query string. This breaks handlers that rely on query params after Vercel route/header processing.

This change copies the original request search/hash onto the reconstructed URL when `x-original-path` does not explicitly provide them.

  ## Changes

  - Preserve `request.url` query string when `x-original-path` is path-only.
  - Keep explicit query strings from `x-original-path` when provided.
  - Add regression tests for both cases.
  - Add a patch changeset.

  ## Related

  Potentially related to #49 and vercel/vercel#11144.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed query string handling to properly preserve the original request's query string when rebuilding requests with pathname-only overrides, while respecting explicitly provided query parameters.

* **Tests**
  * Added unit tests for request rebuilding functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->