### PR TITLE
fix: preserve original request query

### DIFF
--- a/.changeset/brave-ants-smile.md
+++ b/.changeset/brave-ants-smile.md
@@ -1,0 +1,5 @@
+---
+"vite-plugin-vercel": patch
+---
+
+Preserve the original request query string when reconstructing requests from `x-original-path`.

--- a/packages/vite-plugin-vercel/src/utils/request.test.ts
+++ b/packages/vite-plugin-vercel/src/utils/request.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { getOriginalRequest } from "./request";
+
+describe("getOriginalRequest", () => {
+  it("preserves the original request query when x-original-path only contains a pathname", () => {
+    const request = new Request(
+      "https://example.com/webhooks/whatsapp?hub.mode=subscribe&hub.verify_token=token&hub.challenge=local",
+      {
+        headers: {
+          "x-original-path": "/webhooks/whatsapp",
+        },
+      },
+    );
+
+    expect(getOriginalRequest(request).url).toBe(
+      "https://example.com/webhooks/whatsapp?hub.mode=subscribe&hub.verify_token=token&hub.challenge=local",
+    );
+  });
+
+  it("keeps an explicit query from x-original-path", () => {
+    const request = new Request("https://example.com/rewritten?request=value", {
+      headers: {
+        "x-original-path": "/original?original=value",
+      },
+    });
+
+    expect(getOriginalRequest(request).url).toBe("https://example.com/original?original=value");
+  });
+});

--- a/packages/vite-plugin-vercel/src/utils/request.ts
+++ b/packages/vite-plugin-vercel/src/utils/request.ts
@@ -13,10 +13,6 @@ export function getOriginalRequest(request: Request) {
       originalUrl.search = requestUrl.search;
     }
 
-    if (!originalUrl.hash) {
-      originalUrl.hash = requestUrl.hash;
-    }
-
     newUrl = originalUrl.toString();
   }
 

--- a/packages/vite-plugin-vercel/src/utils/request.ts
+++ b/packages/vite-plugin-vercel/src/utils/request.ts
@@ -6,7 +6,18 @@ export function getOriginalRequest(request: Request) {
   let newRequest = request;
 
   if (typeof xOriginalPath === "string") {
-    newUrl = new URL(xOriginalPath, request.url).toString();
+    const requestUrl = new URL(request.url);
+    const originalUrl = new URL(xOriginalPath, requestUrl);
+
+    if (!originalUrl.search) {
+      originalUrl.search = requestUrl.search;
+    }
+
+    if (!originalUrl.hash) {
+      originalUrl.hash = requestUrl.hash;
+    }
+
+    newUrl = originalUrl.toString();
   }
 
   if (newUrl && request.url !== newUrl) {


### PR DESCRIPTION
Run complete CI for #233

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed query string preservation when reconstructing requests. Query parameters are now correctly maintained during the request reconstruction process, ensuring users' original URL parameters are not lost.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->