### PR TITLE
fix: resolve outDir from config.root

### DIFF
--- a/packages/vite-plugin-vercel/src/plugins/clean-outdir.ts
+++ b/packages/vite-plugin-vercel/src/plugins/clean-outdir.ts
@@ -3,8 +3,6 @@ import path from "node:path";
 import type { Plugin } from "vite";
 import type { ViteVercelConfig } from "../types";
 
-const outDir = path.posix.join(process.cwd(), ".vercel/output");
-
 export function vercelCleanupPlugin(pluginConfig: ViteVercelConfig): Plugin {
   let alreadyRun = false;
   return {
@@ -18,7 +16,11 @@ export function vercelCleanupPlugin(pluginConfig: ViteVercelConfig): Plugin {
       handler() {
         if (alreadyRun) return;
         alreadyRun = true;
-        cleanOutputDirectory(pluginConfig.outDir ?? outDir);
+        const root = this.environment?.config?.root ?? process.cwd();
+        const resolvedOutDir = pluginConfig.outDir
+          ? path.resolve(root, pluginConfig.outDir)
+          : path.join(root, ".vercel/output");
+        cleanOutputDirectory(resolvedOutDir);
       },
     },
 

--- a/packages/vite-plugin-vercel/src/plugins/setupEnvs.ts
+++ b/packages/vite-plugin-vercel/src/plugins/setupEnvs.ts
@@ -16,7 +16,6 @@ import { virtualEntry } from "../utils/const.js";
 import { edgeConditions } from "../utils/edge.js";
 import { edgeExternal } from "../utils/external.js";
 
-const outDir = path.posix.join(process.cwd(), ".vercel/output");
 const DUMMY = "__DUMMY__";
 
 let injected = false;
@@ -52,7 +51,7 @@ export function setupEnvs(pluginConfig: ViteVercelConfig): Plugin[] {
 
       config: {
         order: "post",
-        handler() {
+        handler(config) {
           if (!injected) {
             injected = true;
             if (pluginConfig.entries) {
@@ -62,10 +61,15 @@ export function setupEnvs(pluginConfig: ViteVercelConfig): Plugin[] {
             }
           }
 
+          const root = config.root ?? process.cwd();
+          const resolvedOutDir = pluginConfig.outDir
+            ? path.resolve(root, pluginConfig.outDir)
+            : path.join(root, ".vercel/output");
+
           const outDirOverride: EnvironmentOptions = pluginConfig.outDir
             ? {
                 build: {
-                  outDir: pluginConfig.outDir,
+                  outDir: resolvedOutDir,
                 },
               }
             : {};
@@ -75,7 +79,7 @@ export function setupEnvs(pluginConfig: ViteVercelConfig): Plugin[] {
           if (envNames.client) {
             environments[envNames.client] = {
               build: {
-                outDir: path.join(pluginConfig.outDir ?? outDir, "static"),
+                outDir: path.join(resolvedOutDir, "static"),
                 copyPublicDir: true,
                 rollupOptions: {
                   input: getDummyInput(),
@@ -87,11 +91,17 @@ export function setupEnvs(pluginConfig: ViteVercelConfig): Plugin[] {
           }
 
           if (envNames.edge) {
-            environments[envNames.edge] = createVercelEnvironmentOptions(outDirOverride);
+            environments[envNames.edge] = createVercelEnvironmentOptions(
+              resolvedOutDir,
+              outDirOverride,
+            );
           }
 
           if (envNames.node) {
-            environments[envNames.node] = createVercelEnvironmentOptions(outDirOverride);
+            environments[envNames.node] = createVercelEnvironmentOptions(
+              resolvedOutDir,
+              outDirOverride,
+            );
           }
 
           // rollup inputs are computed by the bundle plugin dynamically
@@ -229,7 +239,7 @@ export function setupEnvs(pluginConfig: ViteVercelConfig): Plugin[] {
   ];
 }
 
-function createVercelEnvironmentOptions(overrides?: EnvironmentOptions): EnvironmentOptions {
+function createVercelEnvironmentOptions(outDir: string, overrides?: EnvironmentOptions): EnvironmentOptions {
   return mergeConfig(
     {
       dev: {

--- a/packages/vite-plugin-vercel/src/plugins/setupEnvs.ts
+++ b/packages/vite-plugin-vercel/src/plugins/setupEnvs.ts
@@ -66,14 +66,6 @@ export function setupEnvs(pluginConfig: ViteVercelConfig): Plugin[] {
             ? path.resolve(root, pluginConfig.outDir)
             : path.join(root, ".vercel/output");
 
-          const outDirOverride: EnvironmentOptions = pluginConfig.outDir
-            ? {
-                build: {
-                  outDir: resolvedOutDir,
-                },
-              }
-            : {};
-
           const environments: UserConfig["environments"] = {};
 
           if (envNames.client) {
@@ -91,17 +83,11 @@ export function setupEnvs(pluginConfig: ViteVercelConfig): Plugin[] {
           }
 
           if (envNames.edge) {
-            environments[envNames.edge] = createVercelEnvironmentOptions(
-              resolvedOutDir,
-              outDirOverride,
-            );
+            environments[envNames.edge] = createVercelEnvironmentOptions(resolvedOutDir);
           }
 
           if (envNames.node) {
-            environments[envNames.node] = createVercelEnvironmentOptions(
-              resolvedOutDir,
-              outDirOverride,
-            );
+            environments[envNames.node] = createVercelEnvironmentOptions(resolvedOutDir);
           }
 
           // rollup inputs are computed by the bundle plugin dynamically

--- a/packages/vite-plugin-vercel/src/plugins/setupEnvs.ts
+++ b/packages/vite-plugin-vercel/src/plugins/setupEnvs.ts
@@ -5,7 +5,6 @@ import {
   BuildEnvironment,
   createRunnableDevEnvironment,
   type EnvironmentOptions,
-  mergeConfig,
   type Plugin,
   type UserConfig,
 } from "vite";
@@ -225,40 +224,37 @@ export function setupEnvs(pluginConfig: ViteVercelConfig): Plugin[] {
   ];
 }
 
-function createVercelEnvironmentOptions(outDir: string, overrides?: EnvironmentOptions): EnvironmentOptions {
-  return mergeConfig(
-    {
-      dev: {
-        async createEnvironment(name, config) {
-          return createRunnableDevEnvironment(name, config);
-        },
+function createVercelEnvironmentOptions(outDir: string): EnvironmentOptions {
+  return {
+    dev: {
+      async createEnvironment(name, config) {
+        return createRunnableDevEnvironment(name, config);
       },
-      build: {
-        createEnvironment(name, config) {
-          return new BuildEnvironment(name, config);
-        },
-        outDir,
-        copyPublicDir: false,
-        rollupOptions: {
-          input: getDummyInput(),
-          output: {
-            sanitizeFileName: (filename) => {
-              return filename.replace("\0", "_");
-            },
-            sourcemap: false,
+    },
+    build: {
+      createEnvironment(name, config) {
+        return new BuildEnvironment(name, config);
+      },
+      outDir,
+      copyPublicDir: false,
+      rollupOptions: {
+        input: getDummyInput(),
+        output: {
+          sanitizeFileName: (filename) => {
+            return filename.replace("\0", "_");
           },
+          sourcemap: false,
         },
-        target: "es2022",
-        emptyOutDir: false,
-        emitAssets: true,
       },
+      target: "es2022",
+      emptyOutDir: false,
+      emitAssets: true,
+    },
 
-      consumer: "server",
+    consumer: "server",
 
-      keepProcessEnv: true,
-    } satisfies EnvironmentOptions,
-    overrides ?? {},
-  );
+    keepProcessEnv: true,
+  };
 }
 
 function getDummyInput(): Record<string, string> {


### PR DESCRIPTION
`outDir` was computed at module load time (top-level `const`) based on `process.cwd()`. It was then used as the default `outDir` for all three Vercel environments in the `config` hook. If `process.cwd()` was changed before the plugin was executed the output would end up in the wrong location.

I ran into this issue in Cedar where we have to change `cwd` to a subdirectory (`web/` in our case) before building because `postcss-load-config` resolves plugins via `createRequire(process.cwd())`.

I managed to work around this by doing `vercel({ outDir: '../.vercel/output' })`, but I feel like a proper fix is warranted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Output directories are now resolved against the Vite project root when available, rather than the current working directory, ensuring consistent output paths across builds.
  * Build outputs for static, Edge, and Node environments now use the resolved output directory so artifacts are placed predictably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->