### PR TITLE
fix: copy client build for better SPA support

### DIFF
--- a/packages/vite-plugin-vercel/src/plugins/setupEnvs.ts
+++ b/packages/vite-plugin-vercel/src/plugins/setupEnvs.ts
@@ -320,7 +320,10 @@ async function copyClientOutput(
   const srcDir = path.isAbsolute(clientOutDir)
     ? clientOutDir
     : path.join(topLevelConfig.root, clientOutDir);
-  const destDir = path.join(pluginConfig.outDir ?? outDir, "static");
+  const rawDestDir = vercelClientEnv.config.build.outDir;
+  const destDir = path.isAbsolute(rawDestDir)
+    ? rawDestDir
+    : path.join(topLevelConfig.root, rawDestDir);
 
   // When vercel_client is the **only** client environment, srcDir and destDir
   // resolve to the same path. The files are already in the right place so we

--- a/packages/vite-plugin-vercel/src/plugins/setupEnvs.ts
+++ b/packages/vite-plugin-vercel/src/plugins/setupEnvs.ts
@@ -7,6 +7,7 @@ import {
   type EnvironmentOptions,
   mergeConfig,
   type Plugin,
+  type ResolvedConfig,
   type UserConfig,
 } from "vite";
 import { getConfig } from "../config.js";
@@ -30,12 +31,18 @@ export function setupEnvs(pluginConfig: ViteVercelConfig): Plugin[] {
       buildApp: {
         order: "post",
         async handler(builder) {
-          if (!builder.environments[envNames.client].isBuilt) {
+          const vercelClientEnv = builder.environments[envNames.client];
+
+          if (!vercelClientEnv.isBuilt) {
             try {
-              await builder.build(builder.environments[envNames.client]);
+              await builder.build(vercelClientEnv);
             } catch (e) {
               if (e instanceof Error && e.message.includes(`Could not resolve entry module "index.html"`)) {
-                // ignore error
+                // vercel_client build failed (expected for frameworks without
+                // index.html). We still need to copy the real client output
+                // into .vercel/output/static/ so Vercel can serve SPA shell
+                // files.
+                await copyClientOutput(vercelClientEnv, pluginConfig);
               } else {
                 throw e;
               }
@@ -209,8 +216,21 @@ export function setupEnvs(pluginConfig: ViteVercelConfig): Plugin[] {
           const topLevelConfig = this.environment.getTopLevelConfig();
           const clientEnv = topLevelConfig.environments.client;
           if (clientEnv) {
+            const clientOutDir = clientEnv.build.outDir;
+            const srcDir = path.isAbsolute(clientOutDir)
+              ? clientOutDir
+              : path.join(topLevelConfig.root, clientOutDir);
+            const destDir = this.environment.config.build.outDir;
+
+            // When vercel_client is the **only** client environment, srcDir and
+            // destDir resolve to the same path. That means the files are
+            // already in the right place, so we should skip the copy.
+            if (path.resolve(srcDir) === path.resolve(destDir)) {
+              return;
+            }
+
             try {
-              await cp(path.join(topLevelConfig.root, clientEnv.build.outDir), this.environment.config.build.outDir, {
+              await cp(srcDir, destDir, {
                 recursive: true,
                 force: true,
                 dereference: true,
@@ -276,5 +296,49 @@ function cleanupDummy(bundle: Record<string, unknown>) {
   const dummy = Object.keys(bundle).find((key) => key.includes("_DUMMY_"));
   if (dummy) {
     delete bundle[dummy];
+  }
+}
+
+async function copyClientOutput(
+  vercelClientEnv: {
+    getTopLevelConfig(): ResolvedConfig;
+    config: { build: { outDir: string } };
+  },
+  pluginConfig: ViteVercelConfig,
+) {
+  const topLevelConfig = vercelClientEnv.getTopLevelConfig();
+  if (!topLevelConfig) {
+    return;
+  }
+
+  const clientEnv = topLevelConfig.environments?.client;
+  if (!clientEnv) {
+    return;
+  }
+
+  const clientOutDir = clientEnv.build.outDir;
+  const srcDir = path.isAbsolute(clientOutDir)
+    ? clientOutDir
+    : path.join(topLevelConfig.root, clientOutDir);
+  const destDir = path.join(pluginConfig.outDir ?? outDir, "static");
+
+  // When vercel_client is the **only** client environment, srcDir and destDir
+  // resolve to the same path. The files are already in the right place so we
+  // should skip the copy.
+  if (path.resolve(srcDir) === path.resolve(destDir)) {
+    return;
+  }
+
+  try {
+    await cp(srcDir, destDir, {
+      recursive: true,
+      force: true,
+      dereference: true,
+    });
+  } catch (e) {
+    // ENOENT is expected when the client build hasn't produced output yet
+    if (!(e instanceof Error && e.message.includes("ENOENT"))) {
+      throw e;
+    }
   }
 }

--- a/packages/vite-plugin-vercel/src/plugins/setupEnvs.ts
+++ b/packages/vite-plugin-vercel/src/plugins/setupEnvs.ts
@@ -7,7 +7,6 @@ import {
   type EnvironmentOptions,
   mergeConfig,
   type Plugin,
-  type ResolvedConfig,
   type UserConfig,
 } from "vite";
 import { getConfig } from "../config.js";
@@ -37,17 +36,16 @@ export function setupEnvs(pluginConfig: ViteVercelConfig): Plugin[] {
             try {
               await builder.build(vercelClientEnv);
             } catch (e) {
-              if (e instanceof Error && e.message.includes(`Could not resolve entry module "index.html"`)) {
-                // vercel_client build failed (expected for frameworks without
-                // index.html). We still need to copy the real client output
-                // into .vercel/output/static/ so Vercel can serve SPA shell
-                // files.
-                await copyClientOutput(vercelClientEnv, pluginConfig);
-              } else {
+              // vercel_client builds from a dummy entry, so a missing index.html
+              // is expected and harmless — copyClientOutput copies the real
+              // client output regardless of whether this build produced any.
+              if (!(e instanceof Error && e.message.includes(`Could not resolve entry module "index.html"`))) {
                 throw e;
               }
             }
           }
+          await copyClientOutput(vercelClientEnv);
+
           if (envNames.edge !== false && !builder.environments[envNames.edge].isBuilt) {
             await builder.build(builder.environments[envNames.edge]);
           }
@@ -212,35 +210,6 @@ export function setupEnvs(pluginConfig: ViteVercelConfig): Plugin[] {
       generateBundle: {
         async handler(_opts, bundle) {
           cleanupDummy(bundle);
-
-          const topLevelConfig = this.environment.getTopLevelConfig();
-          const clientEnv = topLevelConfig.environments.client;
-          if (clientEnv) {
-            const clientOutDir = clientEnv.build.outDir;
-            const srcDir = path.isAbsolute(clientOutDir)
-              ? clientOutDir
-              : path.join(topLevelConfig.root, clientOutDir);
-            const destDir = this.environment.config.build.outDir;
-
-            // When vercel_client is the **only** client environment, srcDir and
-            // destDir resolve to the same path. That means the files are
-            // already in the right place, so we should skip the copy.
-            if (path.resolve(srcDir) === path.resolve(destDir)) {
-              return;
-            }
-
-            try {
-              await cp(srcDir, destDir, {
-                recursive: true,
-                force: true,
-                dereference: true,
-              });
-            } catch (e) {
-              if (e instanceof Error && e.message.includes("ENOENT")) {
-                // ignore
-              } else throw e;
-            }
-          }
         },
       },
 
@@ -299,49 +268,21 @@ function cleanupDummy(bundle: Record<string, unknown>) {
   }
 }
 
-async function copyClientOutput(
-  vercelClientEnv: {
-    getTopLevelConfig(): ResolvedConfig;
-    config: { build: { outDir: string } };
-  },
-  pluginConfig: ViteVercelConfig,
-) {
+// Copies the framework's client output into Vercel's static directory so it is
+// served as the SPA shell.
+async function copyClientOutput(vercelClientEnv: BuildEnvironment) {
   const topLevelConfig = vercelClientEnv.getTopLevelConfig();
-  if (!topLevelConfig) {
-    return;
-  }
+  const srcDir = path.resolve(topLevelConfig.root, topLevelConfig.environments.client.build.outDir);
+  const destDir = path.resolve(topLevelConfig.root, vercelClientEnv.config.build.outDir);
 
-  const clientEnv = topLevelConfig.environments?.client;
-  if (!clientEnv) {
-    return;
-  }
-
-  const clientOutDir = clientEnv.build.outDir;
-  const srcDir = path.isAbsolute(clientOutDir)
-    ? clientOutDir
-    : path.join(topLevelConfig.root, clientOutDir);
-  const rawDestDir = vercelClientEnv.config.build.outDir;
-  const destDir = path.isAbsolute(rawDestDir)
-    ? rawDestDir
-    : path.join(topLevelConfig.root, rawDestDir);
-
-  // When vercel_client is the **only** client environment, srcDir and destDir
-  // resolve to the same path. The files are already in the right place so we
-  // should skip the copy.
-  if (path.resolve(srcDir) === path.resolve(destDir)) {
-    return;
-  }
+  // When vercel_client is the only client environment, src and dest are the
+  // same directory and the output is already where Vercel expects it.
+  if (srcDir === destDir) return;
 
   try {
-    await cp(srcDir, destDir, {
-      recursive: true,
-      force: true,
-      dereference: true,
-    });
+    await cp(srcDir, destDir, { recursive: true, force: true, dereference: true });
   } catch (e) {
-    // ENOENT is expected when the client build hasn't produced output yet
-    if (!(e instanceof Error && e.message.includes("ENOENT"))) {
-      throw e;
-    }
+    // The client environment may not have produced any output to copy.
+    if (!(e instanceof Error && "code" in e && e.code === "ENOENT")) throw e;
   }
 }


### PR DESCRIPTION
The `vercel_client` environment's `generateBundle` hook, which copies the real client build output into `.vercel/output/static/`, used `path.join(topLevelConfig.root, clientEnv.build.outDir)` to compute the source directory. When `clientEnv.build.outDir` was already an absolute path (as it is after config resolution), `path.join` concatenated it with the root instead of using it directly, producing a garbled path like `web/private/var/.../web/dist`.
This caused the copy to fail silently (`ENOENT`), leaving `.vercel/output/static/` without `index.html` or assets. This results in 404s for SPA frameworks on Vercel.
Additionally, where `vercel_client` is the only client environment (like in the tanstack example), `srcDir` and `destDir` resolved to the same path. The original garbled path accidentally avoided this, but `cp` throws `EINVAL` when source and destination are identical.

These are the fixes this PR applies:

- Use `path.isAbsolute(outDir) ? outDir : path.join(root, outDir)` to correctly handle both absolute and relative output directories
- Skip the copy when `path.resolve(srcDir) === path.resolve(destDir)` because the files are already in the right place (`vercel_client` is the only client environment)
- Apply the same `path.isAbsolute` fix in the `copyClientOutput` fallback used by the `buildApp` hook

I have tested this by building/packing a local tarball and using that in local tests deployed to Vercel.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tolerate missing client index.html during client environment build and still preserve whatever client output exists.
  * Always copy client output from resolved source to destination, skipping the copy if paths match.
  * Use recursive copy and treat missing output as an expected (non-fatal) condition.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->